### PR TITLE
chore: update cask to v0.15.6

### DIFF
--- a/Casks/markon.rb
+++ b/Casks/markon.rb
@@ -1,9 +1,9 @@
 cask "markon" do
   arch arm: "aarch64", intel: "x64"
 
-  version "0.13.10"
-  sha256 arm:   "b2a44830cc1f07de2d47ed2615ac1a10c59eeecd18ba0870c7db607df4c91804",
-         intel: :no_check
+  version "0.15.6"
+  sha256 arm:   "135b62741681a3bc21f08adbca4cfd73fdd0b703ae3029e94b358ca0ccc76845",
+         intel: "dba1abc6cfffa0cd54de7b608ed50e98ebc798c32f256cfa67b55a9f08f1c850"
 
   url "https://github.com/kookyleo/markon/releases/download/v#{version}/Markon_#{version}_#{arch}.dmg",
       verified: "github.com/kookyleo/markon/"


### PR DESCRIPTION
Update the Homebrew Cask version and DMG checksums for v0.15.6.