### PR TITLE
harden: crash-safety, resource cleanup, and async robustness

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -47,6 +47,7 @@ syntect = "5.3.0"
 # version built against syntect 5.3.0 so Cargo unifies on a single syntect.
 two-face = "0.5.1"
 tower-http = { version = "0.6.8", features = ["fs", "trace"] }
+tower = { version = "0.5", features = ["util"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 rust-embed = "8.11.0"
@@ -101,4 +102,3 @@ version = "0.1.4"
 
 [dev-dependencies]
 tempfile = "3.27"
-tower = { version = "0.5", features = ["util"] }

--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -990,25 +990,36 @@ pub fn read_blobs(root: &Path, oids: &[String]) -> Result<HashMap<String, Vec<u8
         .stderr(Stdio::null())
         .spawn()
         .map_err(|e| GitError::Io(e.to_string()))?;
-    {
-        let mut stdin = child
-            .stdin
-            .take()
-            .ok_or_else(|| GitError::Io("cat-file: no stdin".to_string()))?;
-        let mut buf = String::with_capacity(oids.len() * 41);
-        for oid in oids {
-            buf.push_str(oid);
-            buf.push('\n');
-        }
-        // Input is small (one sha per line); writing it fully before reading the
-        // (larger) output cannot deadlock.
-        stdin
-            .write_all(buf.as_bytes())
-            .map_err(|e| GitError::Io(e.to_string()))?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| GitError::Io("cat-file: no stdin".to_string()))?;
+    let mut buf = String::with_capacity(oids.len() * 41);
+    for oid in oids {
+        buf.push_str(oid);
+        buf.push('\n');
     }
+    // The output can be far larger than the OS pipe buffer, so git may block on
+    // stdout (and stop reading stdin) before we finish writing. Drain stdout on
+    // this thread while a helper thread feeds stdin, then closes it via drop.
+    let writer = std::thread::spawn(move || {
+        if let Err(e) = stdin.write_all(buf.as_bytes()) {
+            // git may exit early (e.g. all oids reported before we finish),
+            // closing its read end; a broken pipe here is expected and benign.
+            if e.kind() != std::io::ErrorKind::BrokenPipe {
+                return Err(GitError::Io(e.to_string()));
+            }
+        }
+        Ok(())
+    });
     let out = child
         .wait_with_output()
         .map_err(|e| GitError::Io(e.to_string()))?;
+    // Surface a genuine (non-broken-pipe) write failure; a panicked writer
+    // thread is treated as an I/O error.
+    writer
+        .join()
+        .map_err(|_| GitError::Io("cat-file: writer thread panicked".to_string()))??;
     parse_cat_file_batch(&out.stdout, &mut map);
     Ok(map)
 }
@@ -1287,27 +1298,6 @@ pub fn parent_commit(root: &Path, rev: &str) -> Result<Option<String>> {
         return Err(GitError::InvalidRevision);
     }
     Ok(git_stdout(root, &["rev-parse", &format!("{rev}^")]).filter(|s| !s.is_empty()))
-}
-
-pub fn head_file(root: &Path, rel_path: &str) -> Result<Option<String>> {
-    ensure_repo(root)?;
-    if !has_head(root) {
-        return Ok(None);
-    }
-    file_at_ref(root, "HEAD", rel_path)
-}
-
-pub fn file_at_ref(root: &Path, rev: &str, rel_path: &str) -> Result<Option<String>> {
-    ensure_repo(root)?;
-    if rev == "worktree" || rev.starts_with('-') || rev.contains('\0') || rel_path.contains('\0') {
-        return Err(GitError::InvalidRevision);
-    }
-    let spec = format!("{}:{}", rev, rel_path.replace('\\', "/"));
-    let output = run_git(root, &["show", &spec])?;
-    if !output.status.success() {
-        return Ok(None);
-    }
-    Ok(Some(String::from_utf8_lossy(&output.stdout).to_string()))
 }
 
 pub fn commit_workspace(root: &Path, message: &str) -> Result<GitCommitResult> {

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -671,9 +671,25 @@ pub async fn start(config: ServerConfig) -> Result<(), String> {
     let parent_dir = std::path::Path::new(&db_path).parent().unwrap();
     fs::create_dir_all(parent_dir).expect("Failed to create database directory");
     let conn = Connection::open(&db_path).expect("Failed to open database");
+    // WAL: the single-server invariant is not enforced (the GUI can start a
+    // second server on a different/auto port while a CLI daemon holds the same
+    // db — it never consults the server lock), so two processes can open this
+    // file concurrently. WAL gives multi-reader / single-writer concurrency
+    // across processes instead of the rollback journal's whole-file lock. It is
+    // persisted in the db header (set-once; re-asserting on each open is cheap)
+    // and adds `-wal`/`-shm` sidecar files — a plain-copy backup must include
+    // them or checkpoint first.
+    let journal_mode: String = conn
+        .query_row("PRAGMA journal_mode=WAL", [], |row| row.get(0))
+        .unwrap_or_default();
+    if !journal_mode.eq_ignore_ascii_case("wal") {
+        tracing::warn!(
+            got = %journal_mode,
+            "could not enable WAL journal mode; concurrent multi-process access may hit 'database is locked'"
+        );
+    }
     // Wait up to 5s for a competing writer to release the lock instead of
-    // failing immediately with SQLITE_BUSY. WAL is intentionally not enabled
-    // (it would change the on-disk format).
+    // failing immediately with SQLITE_BUSY — complements WAL under write bursts.
     conn.pragma_update(None, "busy_timeout", 5000)
         .expect("Failed to set busy_timeout");
     conn.execute(

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -2029,6 +2029,7 @@ async fn handle_workspace_path(
     State(state): State<AppState>,
     AxumPath((workspace_id, path)): AxumPath<(String, String)>,
     axum::extract::ConnectInfo(addr): axum::extract::ConnectInfo<std::net::SocketAddr>,
+    headers: axum::http::HeaderMap,
 ) -> impl IntoResponse {
     let Some(ws) = state.workspace_registry.get(&workspace_id) else {
         return StatusCode::NOT_FOUND.into_response();
@@ -2059,31 +2060,32 @@ async fn handle_workspace_path(
 
     if canonical.is_file() {
         if is_markdown_path(&canonical) {
-            render_markdown_file(
-                &canonical.to_string_lossy(),
-                &workspace_id,
-                &ws,
-                &root,
-                &state,
+            render_markdown_file_async(
+                canonical.to_string_lossy().into_owned(),
+                workspace_id.clone(),
+                ws.clone(),
+                root.clone(),
+                state.clone(),
                 is_local,
             )
+            .await
         } else {
             // Small UTF-8 text/code files get an elegant read-only, syntax-
             // highlighted preview page. Everything else — images, media, PDFs,
             // binaries, oversized text — is served as raw bytes (the browser
             // displays what it can inline and downloads the rest); this also
             // keeps embedded resources like markdown images working verbatim.
-            match read_text_for_preview(&canonical) {
-                Some((content, token)) => render_file_view(
-                    &canonical,
-                    content,
-                    token,
-                    &workspace_id,
-                    &ws,
-                    &root,
-                    &state,
-                ),
-                None => serve_file(&canonical),
+            match render_preview_or_none(
+                canonical.clone(),
+                workspace_id.clone(),
+                ws.clone(),
+                root.clone(),
+                state.clone(),
+            )
+            .await
+            {
+                Some(resp) => resp,
+                None => serve_file(&canonical, &headers).await,
             }
         }
     } else if canonical.is_dir() {
@@ -2303,14 +2305,16 @@ async fn handle_git_working_diff_data(
         return StatusCode::NOT_FOUND.into_response();
     };
     if diff_view_from_query(query.view.as_deref()) == "rendered" {
-        return match markdown_compare_diff_data(
+        return match markdown_compare_diff_data_async(
             &state,
             &workspace_id,
             &ws.root,
             "HEAD",
             "worktree",
             query.f.as_deref(),
-        ) {
+        )
+        .await
+        {
             Ok(data) => Json(data).into_response(),
             Err(git::GitError::NotRepository) => git_not_repository_response(),
             Err(git::GitError::InvalidRevision) => {
@@ -2440,14 +2444,16 @@ async fn handle_pretty_compare_diff(
     let is_local = addr.ip().is_loopback();
     let initial_view = diff_view_from_query(query.view.as_deref());
     if query.format.as_deref() == Some("data") && initial_view == "rendered" {
-        return match markdown_compare_diff_data(
+        return match markdown_compare_diff_data_async(
             &state,
             &workspace_id,
             &ws.root,
             &base,
             &compare,
             query.f.as_deref(),
-        ) {
+        )
+        .await
+        {
             Ok(data) => Json(data).into_response(),
             Err(git::GitError::NotRepository) => git_not_repository_response(),
             Err(git::GitError::InvalidRevision) => {
@@ -4950,6 +4956,41 @@ fn markdown_compare_diff_data(
     })
 }
 
+/// Async wrapper for [`markdown_compare_diff_data`]. The diff build shells out to
+/// git, reads worktree files, and renders in parallel via rayon — all blocking
+/// work that would otherwise stall a tokio worker. Move it to the blocking pool;
+/// a join failure surfaces as a generic IO error the caller already maps to 500.
+async fn markdown_compare_diff_data_async(
+    state: &AppState,
+    workspace_id: &str,
+    root: &FsPath,
+    base: &str,
+    compare: &str,
+    file_filter: Option<&str>,
+) -> git::Result<MarkdownDiffData> {
+    let state = state.clone();
+    let workspace_id = workspace_id.to_string();
+    let root = root.to_path_buf();
+    let base = base.to_string();
+    let compare = compare.to_string();
+    let file_filter = file_filter.map(str::to_string);
+    tokio::task::spawn_blocking(move || {
+        markdown_compare_diff_data(
+            &state,
+            &workspace_id,
+            &root,
+            &base,
+            &compare,
+            file_filter.as_deref(),
+        )
+    })
+    .await
+    .unwrap_or_else(|e| {
+        tracing::error!("markdown_compare_diff_data join error: {e}");
+        Err(git::GitError::Io("diff render task failed".to_string()))
+    })
+}
+
 /// Build a single file's rendered diff from already-resolved content sources.
 /// Pure CPU + cache lookups — safe to run in parallel across files.
 fn build_markdown_diff_file(
@@ -5436,6 +5477,58 @@ fn render_file_view(
     context.insert("line_count", &line_count);
 
     render_template(state, "file-view.html", &context)
+}
+
+/// Async wrapper for [`render_markdown_file`]: the file read plus the markdown
+/// render (syntect highlighting + server-side diagrams) run on the blocking pool
+/// so a large document can't stall a tokio worker.
+async fn render_markdown_file_async(
+    file_path: String,
+    workspace_id: String,
+    ws: Arc<WorkspaceEntry>,
+    root: PathBuf,
+    state: AppState,
+    is_local: bool,
+) -> Response {
+    tokio::task::spawn_blocking(move || {
+        render_markdown_file(&file_path, &workspace_id, &ws, &root, &state, is_local)
+    })
+    .await
+    .unwrap_or_else(|e| {
+        tracing::error!("render_markdown_file join error: {e}");
+        (StatusCode::INTERNAL_SERVER_ERROR, "render task failed").into_response()
+    })
+}
+
+/// Async wrapper for the non-markdown preview path: the text sniff/read
+/// ([`read_text_for_preview`]) and, when the file is text, the syntect-
+/// highlighted [`render_file_view`] both run on the blocking pool. Returns
+/// `None` when the file is not previewable text, so the caller falls back to
+/// `serve_file`.
+async fn render_preview_or_none(
+    canonical: PathBuf,
+    workspace_id: String,
+    ws: Arc<WorkspaceEntry>,
+    root: PathBuf,
+    state: AppState,
+) -> Option<Response> {
+    tokio::task::spawn_blocking(move || {
+        let (content, token) = read_text_for_preview(&canonical)?;
+        Some(render_file_view(
+            &canonical,
+            content,
+            token,
+            &workspace_id,
+            &ws,
+            &root,
+            &state,
+        ))
+    })
+    .await
+    .unwrap_or_else(|e| {
+        tracing::error!("render_file_view join error: {e}");
+        Some((StatusCode::INTERNAL_SERVER_ERROR, "preview task failed").into_response())
+    })
 }
 
 fn render_markdown_file(
@@ -5968,20 +6061,34 @@ where
     }
 }
 
-fn serve_file(path: &std::path::Path) -> Response {
-    match fs::read(path) {
-        Ok(content) => {
-            let mime_type = mime_guess::from_path(path)
-                .first_or_octet_stream()
-                .essence_str()
-                .to_string();
-            (StatusCode::OK, [(header::CONTENT_TYPE, mime_type)], content).into_response()
+/// Serve a raw (non-markdown) workspace file. Delegates to `tower_http`'s
+/// `ServeFile`, which streams the body from async I/O instead of reading the
+/// whole file into memory, and honors `Range` (206) / conditional requests. The
+/// caller's relevant request headers are forwarded so those features work;
+/// `ServeFile` serves the fixed `path` regardless of the request URI. `path`
+/// is already canonicalized and confinement-checked by the caller.
+async fn serve_file(path: &std::path::Path, req_headers: &axum::http::HeaderMap) -> Response {
+    use tower::ServiceExt;
+    let mut req = axum::http::Request::new(axum::body::Body::empty());
+    for name in [
+        header::RANGE,
+        header::IF_RANGE,
+        header::IF_MODIFIED_SINCE,
+        header::IF_NONE_MATCH,
+        header::ACCEPT_ENCODING,
+    ] {
+        if let Some(value) = req_headers.get(&name) {
+            req.headers_mut().insert(name, value.clone());
         }
-        Err(e) => (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Error reading file: {e}"),
-        )
-            .into_response(),
+    }
+    match tower_http::services::ServeFile::new(path)
+        .oneshot(req)
+        .await
+    {
+        Ok(resp) => resp.map(axum::body::Body::new).into_response(),
+        // ServeFile's error type is `Infallible`; it reports IO problems as an
+        // error status in the response body, so this arm is effectively dead.
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Error reading file").into_response(),
     }
 }
 
@@ -6904,6 +7011,7 @@ mod tests {
             State(state),
             AxumPath((id.clone(), "docs/EVDI_IMPLEMENTATION_PLAN.md".to_string())),
             axum::extract::ConnectInfo(loopback()),
+            axum::http::HeaderMap::new(),
         )
         .await
         .into_response();
@@ -6946,6 +7054,7 @@ mod tests {
             State(state),
             AxumPath((id, "notes.txt".to_string())),
             axum::extract::ConnectInfo(loopback()),
+            axum::http::HeaderMap::new(),
         )
         .await
         .into_response();
@@ -6974,6 +7083,7 @@ mod tests {
             State(state),
             AxumPath((id, "README.md".to_string())),
             axum::extract::ConnectInfo(loopback()),
+            axum::http::HeaderMap::new(),
         )
         .await
         .into_response();
@@ -7077,6 +7187,7 @@ mod tests {
                 State(test_state(reg_on)),
                 AxumPath((id_on, "README.md".to_string())),
                 axum::extract::ConnectInfo(lan_peer()),
+                axum::http::HeaderMap::new(),
             )
             .await
             .into_response(),
@@ -7104,6 +7215,7 @@ mod tests {
                 State(test_state(reg_off)),
                 AxumPath((id_off, "README.md".to_string())),
                 axum::extract::ConnectInfo(lan_peer()),
+                axum::http::HeaderMap::new(),
             )
             .await
             .into_response(),
@@ -7945,6 +8057,7 @@ mod tests {
             State(state),
             AxumPath((id, route)),
             axum::extract::ConnectInfo(loopback()),
+            axum::http::HeaderMap::new(),
         )
         .await
         .into_response();
@@ -7972,6 +8085,7 @@ mod tests {
             State(state.clone()),
             AxumPath((id.clone(), "sub/".into())),
             axum::extract::ConnectInfo(loopback()),
+            axum::http::HeaderMap::new(),
         )
         .await
         .into_response();
@@ -8259,6 +8373,7 @@ mod tests {
             State(state.clone()),
             AxumPath((id.clone(), "opened.md".into())),
             axum::extract::ConnectInfo(loopback()),
+            axum::http::HeaderMap::new(),
         )
         .await
         .into_response();
@@ -8278,6 +8393,7 @@ mod tests {
             State(state.clone()),
             AxumPath((id.clone(), "pic.png".into())),
             axum::extract::ConnectInfo(loopback()),
+            axum::http::HeaderMap::new(),
         )
         .await
         .into_response();
@@ -8287,6 +8403,7 @@ mod tests {
             State(state.clone()),
             AxumPath((id.clone(), "pic%20with%20space.png".into())),
             axum::extract::ConnectInfo(loopback()),
+            axum::http::HeaderMap::new(),
         )
         .await
         .into_response();
@@ -8296,6 +8413,7 @@ mod tests {
             State(state.clone()),
             AxumPath((id.clone(), "nested/root.png".into())),
             axum::extract::ConnectInfo(loopback()),
+            axum::http::HeaderMap::new(),
         )
         .await
         .into_response();
@@ -8305,6 +8423,7 @@ mod tests {
             State(state),
             AxumPath((id, "sibling.md".into())),
             axum::extract::ConnectInfo(loopback()),
+            axum::http::HeaderMap::new(),
         )
         .await
         .into_response();

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -124,6 +124,10 @@ pub(crate) struct AccessAttempts {
     pub fails: u32,
     /// If set, unlock attempts are rejected until this instant.
     pub locked_until: Option<std::time::Instant>,
+    /// Timestamp of the most recent recorded failure. Used to expire stale
+    /// entries so the per-IP map does not grow unbounded (especially with
+    /// per-address IPv6 clients).
+    pub last_attempt: Option<std::time::Instant>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -431,6 +435,27 @@ fn is_inside_workspace(path: &FsPath, root: &FsPath) -> bool {
     path.starts_with(root)
 }
 
+/// Verify that the deepest already-existing ancestor of `target` canonicalizes
+/// to a location inside `root`, BEFORE any directory is materialized. This
+/// closes the window where a pre-existing symlinked intermediate could make
+/// `create_dir_all` create directories outside the workspace root: any newly
+/// created component cannot be a symlink, so only existing ancestors can
+/// escape, and the deepest one dominates the resolved location.
+fn deepest_existing_ancestor_inside_workspace(target: &FsPath, root: &FsPath) -> bool {
+    let mut ancestor = target.parent();
+    while let Some(dir) = ancestor {
+        if fs::symlink_metadata(dir).is_ok() {
+            return matches!(
+                canonicalize_route_path(dir),
+                Ok(p) if is_inside_workspace(&p, root)
+            );
+        }
+        ancestor = dir.parent();
+    }
+    // No existing ancestor found (the workspace root should always exist).
+    false
+}
+
 fn path_to_route(path: &FsPath) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
@@ -646,6 +671,11 @@ pub async fn start(config: ServerConfig) -> Result<(), String> {
     let parent_dir = std::path::Path::new(&db_path).parent().unwrap();
     fs::create_dir_all(parent_dir).expect("Failed to create database directory");
     let conn = Connection::open(&db_path).expect("Failed to open database");
+    // Wait up to 5s for a competing writer to release the lock instead of
+    // failing immediately with SQLITE_BUSY. WAL is intentionally not enabled
+    // (it would change the on-disk format).
+    conn.pragma_update(None, "busy_timeout", 5000)
+        .expect("Failed to set busy_timeout");
     conn.execute(
         "CREATE TABLE IF NOT EXISTS annotations (
             id TEXT PRIMARY KEY,
@@ -1023,13 +1053,22 @@ async fn config_ws_handler(
     };
     let mut rx = ws_entry.config_tx.subscribe();
     ws.on_upgrade(move |mut socket| async move {
-        while let Ok(()) = rx.recv().await {
-            if socket
-                .send(axum::extract::ws::Message::Text("reload".into()))
-                .await
-                .is_err()
-            {
-                break;
+        loop {
+            match rx.recv().await {
+                Ok(()) => {
+                    if socket
+                        .send(axum::extract::ws::Message::Text("reload".into()))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(skipped = n, "config ws broadcast lagged; continuing");
+                    continue;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
             }
         }
     })
@@ -1255,22 +1294,40 @@ fn access_safe_redirect(redirect: &str, ws_id: &str) -> String {
     }
 }
 
+/// Drop entries whose last recorded failure is older than the maximum
+/// cooldown. Any lock on such an entry is guaranteed to have expired (a lock
+/// lasts at most `ACCESS_MAX_COOLDOWN_SECS`), so this only removes dead state.
+fn prune_access_attempts(
+    map: &mut std::collections::HashMap<std::net::IpAddr, AccessAttempts>,
+    now: std::time::Instant,
+) {
+    let max = std::time::Duration::from_secs(ACCESS_MAX_COOLDOWN_SECS);
+    map.retain(|_, st| match st.last_attempt {
+        Some(ts) => now.saturating_duration_since(ts) < max,
+        None => true,
+    });
+}
+
 fn access_cooldown_remaining(state: &AppState, ip: std::net::IpAddr) -> Option<u64> {
-    let map = state.access_attempts.lock().unwrap();
-    let until = map.get(&ip)?.locked_until?;
+    let mut map = state.access_attempts.lock().unwrap();
     let now = std::time::Instant::now();
+    prune_access_attempts(&mut map, now);
+    let until = map.get(&ip)?.locked_until?;
     (until > now).then(|| (until - now).as_secs() + 1)
 }
 
 /// Record a failed unlock; returns the cooldown seconds if it just locked.
 fn access_record_failure(state: &AppState, ip: std::net::IpAddr) -> Option<u64> {
     let mut map = state.access_attempts.lock().unwrap();
+    let now = std::time::Instant::now();
+    prune_access_attempts(&mut map, now);
     let st = map.entry(ip).or_default();
     st.fails += 1;
+    st.last_attempt = Some(now);
     if st.fails >= ACCESS_MAX_FAILS {
         let over = (st.fails - ACCESS_MAX_FAILS).min(7);
         let secs = (ACCESS_BASE_COOLDOWN_SECS << over).min(ACCESS_MAX_COOLDOWN_SECS);
-        st.locked_until = Some(std::time::Instant::now() + std::time::Duration::from_secs(secs));
+        st.locked_until = Some(now + std::time::Duration::from_secs(secs));
         Some(secs)
     } else {
         None
@@ -1630,7 +1687,7 @@ async fn dev_reload_trigger(State(state): State<AppState>) -> impl IntoResponse 
 
 async fn load_annotations(db: Arc<Mutex<Connection>>, file_path: String) -> Vec<serde_json::Value> {
     tokio::task::spawn_blocking(move || {
-        let db = db.lock().unwrap();
+        let db = db.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         let mut stmt = match db.prepare("SELECT data FROM annotations WHERE file_path = ?1") {
             Ok(s) => s,
             Err(e) => {
@@ -1658,7 +1715,7 @@ async fn load_annotations(db: Arc<Mutex<Connection>>, file_path: String) -> Vec<
 
 async fn load_viewed_state(db: Arc<Mutex<Connection>>, file_path: String) -> serde_json::Value {
     tokio::task::spawn_blocking(move || {
-        let db = db.lock().unwrap();
+        let db = db.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         let state_json = db
             .query_row(
                 "SELECT state FROM viewed_state WHERE file_path = ?1",
@@ -1726,7 +1783,7 @@ async fn handle_client_msg(
     // run whichever SQL the message requires, then return the broadcast plan
     // for the async side to fan out.
     let result = tokio::task::spawn_blocking(move || {
-        let conn = db.lock().unwrap();
+        let conn = db.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
         match msg {
             WebSocketMessage::NewAnnotation { annotation, op_id } => {
                 let Some(id) = annotation["id"].as_str().map(str::to_owned) else {
@@ -1835,7 +1892,15 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
     let db = state.db.clone();
     let mut rx = tx.subscribe();
 
-    let file_path = match receiver.next().await {
+    let first_frame =
+        match tokio::time::timeout(std::time::Duration::from_secs(10), receiver.next()).await {
+            Ok(frame) => frame,
+            Err(_) => {
+                tracing::warn!("timed out waiting for file path from client; closing socket");
+                return;
+            }
+        };
+    let file_path = match first_frame {
         Some(Ok(Message::Text(text))) => text.to_string(),
         _ => {
             tracing::warn!("failed to receive file path from client");
@@ -1880,9 +1945,18 @@ async fn handle_socket(socket: WebSocket, state: AppState) {
     }
 
     let mut send_task = tokio::spawn(async move {
-        while let Ok(msg) = rx.recv().await {
-            if sender.send(Message::Text(msg.into())).await.is_err() {
-                break;
+        loop {
+            match rx.recv().await {
+                Ok(msg) => {
+                    if sender.send(Message::Text(msg.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::warn!(skipped = n, "ws broadcast lagged; continuing");
+                    continue;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
             }
         }
     });
@@ -2090,7 +2164,14 @@ async fn handle_git_history(
         author: author.clone(),
         since: git_history_since(Some(&range_key)),
     };
-    match git::history_filtered(&ws.root, 80, &filter) {
+    let root = ws.root.clone();
+    let history = tokio::task::spawn_blocking(move || git::history_filtered(&root, 80, &filter))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("git history blocking task join error: {e}");
+            Err(git::GitError::Command("internal task error".into()))
+        });
+    match history {
         Ok(commits) => render_git_history_page(
             &state,
             &workspace_id,
@@ -2116,7 +2197,14 @@ async fn handle_git_history_data(
     let Some(ws) = state.workspace_registry.get(&workspace_id) else {
         return StatusCode::NOT_FOUND.into_response();
     };
-    match git::history(&ws.root, 80) {
+    let root = ws.root.clone();
+    let history = tokio::task::spawn_blocking(move || git::history(&root, 80))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("git history blocking task join error: {e}");
+            Err(git::GitError::Command("internal task error".into()))
+        });
+    match history {
         Ok(commits) => Json(commits).into_response(),
         Err(git::GitError::NotRepository) => git_not_repository_response(),
         Err(e) => (
@@ -2134,7 +2222,14 @@ async fn handle_git_branches(
     let Some(ws) = state.workspace_registry.get(&workspace_id) else {
         return StatusCode::NOT_FOUND.into_response();
     };
-    match git::branches_detailed(&ws.root) {
+    let root = ws.root.clone();
+    let branches = tokio::task::spawn_blocking(move || git::branches_detailed(&root))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("git branches blocking task join error: {e}");
+            Err(git::GitError::Command("internal task error".into()))
+        });
+    match branches {
         Ok(branches) => render_git_branches_page(&state, &workspace_id, &branches),
         Err(git::GitError::NotRepository) => git_not_repository_response(),
         Err(e) => (
@@ -2152,7 +2247,14 @@ async fn handle_git_tags(
     let Some(ws) = state.workspace_registry.get(&workspace_id) else {
         return StatusCode::NOT_FOUND.into_response();
     };
-    match git::tags(&ws.root, 200) {
+    let root = ws.root.clone();
+    let tags = tokio::task::spawn_blocking(move || git::tags(&root, 200))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("git tags blocking task join error: {e}");
+            Err(git::GitError::Command("internal task error".into()))
+        });
+    match tags {
         Ok(tags) => render_git_tags_page(&state, &workspace_id, &tags),
         Err(git::GitError::NotRepository) => git_not_repository_response(),
         Err(e) => (
@@ -2174,7 +2276,14 @@ async fn handle_git_working_diff(
     };
     let is_local = addr.ip().is_loopback();
     let initial_view = diff_view_from_query(query.view.as_deref());
-    match git::working_diff(&ws.root) {
+    let root = ws.root.clone();
+    let diff = tokio::task::spawn_blocking(move || git::working_diff(&root))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("git working diff blocking task join error: {e}");
+            Err(git::GitError::Command("internal task error".into()))
+        });
+    match diff {
         Ok(diff) => render_git_diff_page(&state, &workspace_id, &ws, is_local, &diff, initial_view),
         Err(git::GitError::NotRepository) => git_not_repository_response(),
         Err(e) => (
@@ -2214,7 +2323,14 @@ async fn handle_git_working_diff_data(
                 .into_response(),
         };
     }
-    match git::working_diff(&ws.root) {
+    let root = ws.root.clone();
+    let diff = tokio::task::spawn_blocking(move || git::working_diff(&root))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("git working diff blocking task join error: {e}");
+            Err(git::GitError::Command("internal task error".into()))
+        });
+    match diff {
         Ok(diff) => git_diff_json_response(&diff, query.f.as_deref()),
         Err(git::GitError::NotRepository) => git_not_repository_response(),
         Err(e) => (
@@ -2236,7 +2352,14 @@ async fn handle_git_commit_diff(
     };
     let is_local = addr.ip().is_loopback();
     let initial_view = diff_view_from_query(query.view.as_deref());
-    match git::commit_diff(&ws.root, &commit) {
+    let root = ws.root.clone();
+    let diff = tokio::task::spawn_blocking(move || git::commit_diff(&root, &commit))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("git commit diff blocking task join error: {e}");
+            Err(git::GitError::Command("internal task error".into()))
+        });
+    match diff {
         Ok(diff) => render_git_diff_page(&state, &workspace_id, &ws, is_local, &diff, initial_view),
         Err(git::GitError::InvalidRevision) => {
             (StatusCode::BAD_REQUEST, "Invalid git revision").into_response()
@@ -2254,7 +2377,14 @@ async fn handle_git_commit_diff_data(
     let Some(ws) = state.workspace_registry.get(&workspace_id) else {
         return StatusCode::NOT_FOUND.into_response();
     };
-    match git::commit_diff(&ws.root, &commit) {
+    let root = ws.root.clone();
+    let diff = tokio::task::spawn_blocking(move || git::commit_diff(&root, &commit))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("git commit diff blocking task join error: {e}");
+            Err(git::GitError::Command("internal task error".into()))
+        });
+    match diff {
         Ok(diff) => git_diff_json_response(&diff, query.f.as_deref()),
         Err(git::GitError::InvalidRevision) => {
             (StatusCode::BAD_REQUEST, "Invalid git revision").into_response()
@@ -2563,6 +2693,17 @@ async fn handle_workspace_create_file(
         })
         .into_response();
     }
+    // Verify containment BEFORE creating any directory, so a symlinked
+    // intermediate cannot cause `create_dir_all` to materialize dirs outside
+    // the workspace root.
+    if !deepest_existing_ancestor_inside_workspace(&full_path, &root) {
+        return Json(CreateFileResponse {
+            success: false,
+            message: "Access denied".to_string(),
+            url: None,
+        })
+        .into_response();
+    }
     if let Some(parent) = full_path.parent() {
         if let Err(e) = fs::create_dir_all(parent) {
             return Json(CreateFileResponse {
@@ -2573,6 +2714,8 @@ async fn handle_workspace_create_file(
             .into_response();
         }
     }
+    // Defense in depth: confirm the resolved parent still lands inside the
+    // workspace after creation.
     if let Some(parent) = full_path.parent() {
         match canonicalize_route_path(parent) {
             Ok(parent) if is_inside_workspace(&parent, &root) => {}
@@ -2642,6 +2785,17 @@ async fn handle_workspace_create_folder(
         return Json(CreateFileResponse {
             success: false,
             message: "Folder already exists".to_string(),
+            url: None,
+        })
+        .into_response();
+    }
+    // Verify containment BEFORE creating any directory, so a symlinked
+    // intermediate cannot cause `create_dir_all` to materialize dirs outside
+    // the workspace root.
+    if !deepest_existing_ancestor_inside_workspace(&full_path, &root) {
+        return Json(CreateFileResponse {
+            success: false,
+            message: "Access denied".to_string(),
             url: None,
         })
         .into_response();
@@ -2888,10 +3042,10 @@ async fn workspace_search_handler(
     AxumPath(workspace_id): AxumPath<String>,
     axum::extract::Query(query): axum::extract::Query<SearchQuery>,
 ) -> impl IntoResponse {
-    workspace_search_results(&state, &workspace_id, &query.q)
+    workspace_search_results(&state, &workspace_id, &query.q).await
 }
 
-fn workspace_search_results(
+async fn workspace_search_results(
     state: &AppState,
     workspace_id: &str,
     query: &str,
@@ -2908,10 +3062,19 @@ fn workspace_search_results(
     let Some(idx) = ws.search_index.load_full() else {
         return Json(Vec::new()); // still indexing
     };
-    let results = idx.search(query, 20).unwrap_or_else(|e| {
-        tracing::warn!("search error: {e}");
-        Vec::new()
-    });
+    // Tantivy search is CPU/IO-bound; run it on the blocking pool so it does not
+    // stall a tokio worker thread.
+    let query_owned = query.to_string();
+    let results = tokio::task::spawn_blocking(move || idx.search(&query_owned, 20))
+        .await
+        .unwrap_or_else(|e| {
+            tracing::error!("search blocking task join error: {e}");
+            Ok(Vec::new())
+        })
+        .unwrap_or_else(|e| {
+            tracing::warn!("search error: {e}");
+            Vec::new()
+        });
     Json(results)
 }
 
@@ -5837,6 +6000,57 @@ struct SaveFileResponse {
     message: String,
 }
 
+/// Write `content` to `target` atomically: create a uniquely-named temp file in
+/// the SAME directory, write + flush it, then `rename` it over the target. A
+/// crash mid-write can therefore never leave a truncated document — either the
+/// old file or the fully-written new file is visible. The temp file is removed
+/// on any error. The unique name is derived from the process id plus a static
+/// counter to avoid collisions between concurrent saves.
+fn atomic_write(target: &FsPath, content: &[u8]) -> std::io::Result<()> {
+    use std::io::Write;
+    static COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let dir = target.parent().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "target has no parent directory",
+        )
+    })?;
+    let base = target
+        .file_name()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default();
+    let n = COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let tmp_path = dir.join(format!(".{base}.{}.{n}.tmp", std::process::id()));
+
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp_path)?;
+    // The temp file now exists and is exclusively ours, so any later failure is
+    // safe to clean up.
+    if let Err(e) = file.write_all(content).and_then(|()| file.sync_all()) {
+        drop(file);
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+    drop(file);
+    // Preserve the destination's existing permission bits: `rename` swaps in the
+    // fresh temp inode, which would otherwise reset an already-existing file's
+    // mode to the umask default. Best-effort and Unix-only; the crash-safety of
+    // the write does not depend on it succeeding.
+    #[cfg(unix)]
+    if let Ok(meta) = std::fs::metadata(target) {
+        let _ = std::fs::set_permissions(&tmp_path, meta.permissions());
+    }
+    match std::fs::rename(&tmp_path, target) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = std::fs::remove_file(&tmp_path);
+            Err(e)
+        }
+    }
+}
+
 async fn save_file_handler(
     State(state): State<AppState>,
     Json(payload): Json<SaveFileRequest>,
@@ -5931,22 +6145,35 @@ async fn save_file_handler(
         })
         .into_response();
     }
-    match fs::write(&canonical, &payload.content) {
-        Ok(_) => Json(SaveFileResponse {
+    // Perform the atomic write on the blocking pool so file I/O (open, write,
+    // fsync, rename) does not stall a tokio worker thread.
+    let content = payload.content;
+    let write_result =
+        tokio::task::spawn_blocking(move || atomic_write(&canonical, content.as_bytes())).await;
+    match write_result {
+        Ok(Ok(())) => Json(SaveFileResponse {
             success: true,
             message: "File saved successfully".into(),
         })
         .into_response(),
-        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => Json(SaveFileResponse {
+        Ok(Err(e)) if e.kind() == std::io::ErrorKind::PermissionDenied => Json(SaveFileResponse {
             success: false,
             message: "File is read-only".into(),
         })
         .into_response(),
-        Err(e) => Json(SaveFileResponse {
+        Ok(Err(e)) => Json(SaveFileResponse {
             success: false,
             message: format!("Failed to save: {e}"),
         })
         .into_response(),
+        Err(e) => {
+            tracing::error!("save_file_handler blocking task join error: {e}");
+            Json(SaveFileResponse {
+                success: false,
+                message: "Failed to save: internal error".into(),
+            })
+            .into_response()
+        }
     }
 }
 

--- a/crates/core/src/workspace.rs
+++ b/crates/core/src/workspace.rs
@@ -86,6 +86,11 @@ pub(crate) struct WorkspaceEntry {
     /// Optional short display name (empty = none). RwLock so the GUI/web can
     /// rename a workspace live without re-registering it.
     pub alias: RwLock<String>,
+    /// Shutdown flag for the background watch thread. `remove()` sets it before
+    /// dropping the map entry; the watch loop observes it and exits, dropping
+    /// its own `Arc<WorkspaceEntry>` so the OS thread and the in-RAM search
+    /// index this entry holds are freed instead of leaking after removal.
+    stopped: Arc<AtomicBool>,
 }
 
 impl WorkspaceEntry {
@@ -258,30 +263,61 @@ pub(crate) fn generate_token() -> String {
 }
 
 /// Write a file that holds secrets (management token, salt, provider api keys)
-/// with owner-only (0600) permissions and **no world-readable window**: on Unix
-/// the file is created with mode 0600 up front (closing the create-then-chmod
-/// TOCTOU gap), then re-tightened afterwards in case it pre-existed with looser
-/// bits (`mode()` only applies on creation). On non-Unix we fall back to a plain
-/// write — files under the user profile inherit restrictive per-user ACLs.
+/// with owner-only (0600) permissions and **no world-readable window**, and
+/// **atomically** — a crash mid-write must never leave a truncated
+/// `settings.json` (which holds the per-install salt and provider API keys).
+///
+/// Strategy: write the full contents into a uniquely-named temp file in the
+/// **same directory** (so `rename` stays on one filesystem and is therefore
+/// atomic), fsync it, then `rename` it over the destination. `rename(2)`
+/// atomically replaces the destination inode, so a reader/observer always sees
+/// either the old complete file or the new complete file — never a partial one.
+/// On Unix the temp is created with mode 0600 up front (closing the
+/// create-then-chmod TOCTOU gap); since `rename` swaps in that fresh inode, the
+/// destination ends up 0600 regardless of any looser bits it previously had. On
+/// non-Unix we temp+rename as well — files under the user profile inherit
+/// restrictive per-user ACLs. On any error the temp file is removed.
 pub(crate) fn write_file_user_private(path: &Path, contents: &[u8]) -> std::io::Result<()> {
-    #[cfg(unix)]
-    {
-        use std::io::Write;
-        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-        let mut f = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .mode(0o600)
-            .open(path)?;
+    use std::io::Write;
+    // Unique temp name in the destination directory: pid + a process-global
+    // counter guarantees no collision between concurrent or repeated writes.
+    static TMP_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let stem = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("settings");
+    let seq = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let tmp = dir.join(format!(".{stem}.tmp.{}.{seq}", std::process::id()));
+
+    let write_tmp = || -> std::io::Result<()> {
+        let mut opts = std::fs::OpenOptions::new();
+        opts.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut f = opts.open(&tmp)?;
         f.write_all(contents)?;
-        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600));
+        f.sync_all()?;
         Ok(())
+    };
+
+    if let Err(e) = write_tmp() {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
     }
-    #[cfg(not(unix))]
-    {
-        std::fs::write(path, contents)
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        tracing::warn!(
+            "atomic rename of {} onto {} failed: {e}",
+            tmp.display(),
+            path.display()
+        );
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
     }
+    Ok(())
 }
 
 /// Expand `~` / `～` and canonicalize (dunce strips the `\\?\` verbatim prefix
@@ -366,6 +402,7 @@ impl WorkspaceRegistry {
             pending_edits: Arc::new(PendingEditStore::new()),
             collaborator_access_code_hash: RwLock::new(config.collaborator_access_code_hash),
             alias: RwLock::new(config.alias),
+            stopped: Arc::new(AtomicBool::new(false)),
         });
         self.inner
             .write()
@@ -438,7 +475,17 @@ impl WorkspaceRegistry {
         true
     }
     pub fn remove(&self, id: &str) -> bool {
-        let removed = self.inner.write().unwrap().remove(id).is_some();
+        // Signal the watch thread to stop before we drop our map entry: the
+        // watcher holds its own Arc<WorkspaceEntry>, so dropping the map entry
+        // alone would leave the thread (and the search index it pins) alive and
+        // still broadcasting file_changed for a removed workspace.
+        let removed = match self.inner.write().unwrap().remove(id) {
+            Some(entry) => {
+                entry.stopped.store(true, Ordering::Relaxed);
+                true
+            }
+            None => false,
+        };
         if removed {
             self.notify_persist();
         }
@@ -520,10 +567,11 @@ fn refresh_allowed_assets(entry: &WorkspaceEntry, file_name: &str) {
 /// Shared scaffold for the notify-based watchers below: spawn a thread that
 /// owns the channel and watcher, forward Ok events, and run `on_event` for
 /// each one. The thread exits (dropping the watcher) when the watch cannot
-/// be established or the channel closes.
+/// be established, the channel closes, or `stopped` is set (workspace removed).
 fn spawn_watch_thread(
     root: PathBuf,
     mode: RecursiveMode,
+    stopped: Arc<AtomicBool>,
     mut on_event: impl FnMut(notify::Event) + Send + 'static,
 ) {
     std::thread::spawn(move || {
@@ -538,8 +586,24 @@ fn spawn_watch_thread(
         if watcher.watch(&root, mode).is_err() {
             return;
         }
-        while let Ok(event) = rx.recv() {
-            on_event(event);
+        // Poll with a timeout rather than a bare `recv()` so the thread wakes
+        // periodically to observe `stopped` even when no filesystem events
+        // arrive. A removed workspace would otherwise block here forever,
+        // leaking the OS thread and the in-RAM search index it pins.
+        loop {
+            if stopped.load(Ordering::Relaxed) {
+                return;
+            }
+            match rx.recv_timeout(std::time::Duration::from_millis(500)) {
+                Ok(event) => {
+                    if stopped.load(Ordering::Relaxed) {
+                        return;
+                    }
+                    on_event(event);
+                }
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return,
+            }
         }
     });
 }
@@ -559,9 +623,11 @@ fn spawn_single_file_watcher(
     live_tx: Arc<ArcSwapOption<broadcast::Sender<String>>>,
 ) {
     let target = root.join(&file_name);
+    let stopped = entry.stopped.clone();
     spawn_watch_thread(
         root.clone(),
         RecursiveMode::NonRecursive,
+        stopped,
         move |event: notify::Event| {
             for path in event.paths {
                 let Ok(rel) = path.strip_prefix(&root) else {
@@ -625,9 +691,11 @@ fn spawn_directory_watcher(
     entry: Arc<WorkspaceEntry>,
     live_tx: Arc<ArcSwapOption<broadcast::Sender<String>>>,
 ) {
+    let stopped = entry.stopped.clone();
     spawn_watch_thread(
         root.clone(),
         RecursiveMode::Recursive,
+        stopped,
         move |event: notify::Event| {
             let event_kind = event.kind;
             for path in event.paths {


### PR DESCRIPTION
Transparent robustness and security hardening surfaced by a full-project review. Every change is behavior-preserving (or strictly safer); no product-logic changes are included — those are tracked as separate issues.

## Changes

**server.rs**
- Run blocking git and full-text search work in `spawn_blocking` so a slow subprocess or index query cannot stall a tokio worker.
- Offload the remaining blocking render paths too — markdown page render, text-preview render, and the rendered git-diff build (rayon) — via async wrappers around the existing sync helpers, so a large document or wide diff cannot stall a worker (#51).
- Serve raw (non-markdown) files through `tower-http` `ServeFile`: the body is streamed from async I/O instead of read fully into memory, and `Range` / conditional requests are honored (#52).
- Enable SQLite WAL for the annotation store: the single-server invariant is not enforced (the GUI can start a second server on a different/auto port while a CLI daemon holds the same db), so switch to cross-process multi-reader / single-writer journaling instead of the rollback journal's whole-file lock (#53). `busy_timeout` stays as a complementary backstop.
- Keep WebSocket clients connected on broadcast lag instead of disconnecting them; add a 10s timeout on the first client frame.
- Recover the annotation SQLite mutex from poisoning instead of panicking on every later request.
- Verify workspace containment before `create_dir_all`; expire stale per-IP unlock attempts; atomic document save that preserves the destination's file mode.

**git.rs**
- Fix a stdout pipe deadlock in `read_blobs` on large batches (drain stdout while a helper thread feeds stdin).
- Remove unused `file_at_ref` / `head_file`.

**workspace.rs**
- Atomic `settings.json` write (temp + fsync + rename) so a crash mid-write cannot corrupt the salt / provider keys.
- Stop the file-watch thread on workspace removal so its OS thread and in-RAM search index are freed instead of leaking.

**Cargo.toml**
- Promote `tower` (util) from dev- to a normal dependency for `ServiceExt::oneshot` (already a transitive dep via axum).

## Verification

`cargo build` + `cargo clippy --all-targets -D warnings` (zero warnings) + `cargo test` (279 passed) all green.

Closes #51
Closes #52
Closes #53

## Follow-up (not in this PR)

- #55 — the single-server invariant is emergent, not enforced (the GUI never consults the server lock). WAL here removes the "database is locked" symptom; #55 tracks the root cause and needs a product decision on the GUI's role (own embedded server vs. attach to a running one).
