### PR TITLE
Route bulk file access through workspace capabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3585,7 +3585,7 @@ dependencies = [
 
 [[package]]
 name = "markon"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "clap",
  "dialoguer",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "markon-core"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "markon-gui"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "dirs",
  "dunce",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [workspace.package]
-version = "0.15.12"
+version = "0.15.13"
 edition = "2021"
 authors = ["kookyleo"]
 license = "Apache-2.0"

--- a/crates/core/src/chat/tools/list_dir.rs
+++ b/crates/core/src/chat/tools/list_dir.rs
@@ -83,6 +83,9 @@ impl Tool for ListDirTool {
                 continue;
             }
             let path = entry.path();
+            if ctx.route_for_path(path).is_none() {
+                continue;
+            }
             let name = match path.file_name() {
                 Some(n) => n.to_string_lossy().into_owned(),
                 None => continue,
@@ -92,7 +95,9 @@ impl Tool for ListDirTool {
             if is_dir {
                 dirs.push(name);
             } else {
-                let len = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+                let len = std::fs::symlink_metadata(path)
+                    .map(|metadata| metadata.len())
+                    .unwrap_or(0);
                 files.push((name, len));
             }
         }
@@ -241,5 +246,26 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, ToolError::InvalidArgument(_)));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn omits_symlink_targets_outside_workspace() {
+        use std::os::unix::fs::symlink;
+
+        let td = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let secret = outside.path().join("secret.txt");
+        fs::write(&secret, b"secret").unwrap();
+        symlink(&secret, td.path().join("linked-secret.txt")).unwrap();
+
+        let out = ListDirTool
+            .run(&ctx_for(&td), serde_json::json!({}))
+            .await
+            .unwrap();
+        assert!(
+            !out.contains("linked-secret.txt"),
+            "outside link leaked: {out}"
+        );
     }
 }

--- a/crates/core/src/git.rs
+++ b/crates/core/src/git.rs
@@ -4,6 +4,8 @@ use std::io::Write;
 use std::path::Path;
 use std::process::{Command, Output, Stdio};
 
+use crate::workspace_fs::WorkspaceFs;
+
 #[derive(Debug, Clone, Serialize)]
 pub struct GitStatus {
     pub available: bool,
@@ -611,7 +613,10 @@ pub fn last_commits_for_paths(
     Ok(commits)
 }
 
-pub fn working_diff(root: &Path) -> Result<GitDiff> {
+pub(crate) fn working_diff(workspace_fs: &WorkspaceFs) -> Result<GitDiff> {
+    let root = workspace_fs
+        .directory_root()
+        .ok_or_else(|| GitError::Io("directory workspace required".to_string()))?;
     ensure_repo(root)?;
     let mut patch = if has_head(root) {
         git_stdout_required(
@@ -621,7 +626,7 @@ pub fn working_diff(root: &Path) -> Result<GitDiff> {
     } else {
         String::new()
     };
-    append_untracked_file_patches(root, &mut patch, None);
+    append_untracked_file_patches(workspace_fs, &mut patch, None);
     let files = parse_diff_files(&patch);
     Ok(GitDiff {
         range: "HEAD..worktree".to_string(),
@@ -632,16 +637,23 @@ pub fn working_diff(root: &Path) -> Result<GitDiff> {
     })
 }
 
-pub fn compare_diff(root: &Path, base: &str, compare: &str) -> Result<GitDiff> {
-    compare_diff_with_pathspec(root, base, compare, None)
+pub(crate) fn compare_diff(
+    workspace_fs: &WorkspaceFs,
+    base: &str,
+    compare: &str,
+) -> Result<GitDiff> {
+    compare_diff_with_pathspec(workspace_fs, base, compare, None)
 }
 
 fn compare_diff_with_pathspec(
-    root: &Path,
+    workspace_fs: &WorkspaceFs,
     base: &str,
     compare: &str,
     pathspec: Option<&str>,
 ) -> Result<GitDiff> {
+    let root = workspace_fs
+        .directory_root()
+        .ok_or_else(|| GitError::Io("directory workspace required".to_string()))?;
     ensure_repo(root)?;
     let base = validate_compare_ref(root, base, false)?;
     let compare = validate_compare_ref(root, compare, true)?;
@@ -676,7 +688,7 @@ fn compare_diff_with_pathspec(
     };
     if compare == "worktree" {
         let untracked_filter = (pathspec != ".").then_some(pathspec);
-        append_untracked_file_patches(root, &mut patch, untracked_filter);
+        append_untracked_file_patches(workspace_fs, &mut patch, untracked_filter);
     }
     let range = format!("{base}..{compare}");
     let files = parse_diff_files(&patch);
@@ -718,11 +730,14 @@ pub struct MarkdownDiffListing {
 /// Enumerate the markdown files changed between `base` and `compare` using
 /// `git diff --raw` (no patch generation) plus untracked markdown for worktree
 /// compares. Cheap: one `git diff --raw` and, for worktree, one `ls-files`.
-pub fn markdown_diff_listing(
-    root: &Path,
+pub(crate) fn markdown_diff_listing(
+    workspace_fs: &WorkspaceFs,
     base: &str,
     compare: &str,
 ) -> Result<MarkdownDiffListing> {
+    let root = workspace_fs
+        .directory_root()
+        .ok_or_else(|| GitError::Io("directory workspace required".to_string()))?;
     ensure_repo(root)?;
     let base = validate_compare_ref(root, base, false)?;
     let compare = validate_compare_ref(root, compare, true)?;
@@ -789,7 +804,8 @@ pub fn markdown_diff_listing(
         ) {
             for rel in list {
                 if is_markdown_git_path(&rel) {
-                    let additions = std::fs::read_to_string(root.join(&rel))
+                    let additions = workspace_fs
+                        .read_content_to_string(&rel)
                         .map(|c| c.lines().count())
                         .unwrap_or(0);
                     entries.push(MarkdownDiffEntry {
@@ -1370,7 +1386,14 @@ fn validate_compare_ref(root: &Path, value: &str, allow_worktree: bool) -> Resul
     Err(GitError::InvalidRevision)
 }
 
-fn append_untracked_file_patches(root: &Path, patch: &mut String, path_filter: Option<&str>) {
+fn append_untracked_file_patches(
+    workspace_fs: &WorkspaceFs,
+    patch: &mut String,
+    path_filter: Option<&str>,
+) {
+    let Some(root) = workspace_fs.directory_root() else {
+        return;
+    };
     let untracked = git_stdout(
         root,
         &["ls-files", "--others", "--exclude-standard", "--", "."],
@@ -1383,7 +1406,7 @@ fn append_untracked_file_patches(root: &Path, patch: &mut String, path_filter: O
         if !patch.is_empty() && !patch.ends_with('\n') {
             patch.push('\n');
         }
-        patch.push_str(&untracked_file_patch(root, rel));
+        patch.push_str(&untracked_file_patch(workspace_fs, rel));
     }
 }
 
@@ -1469,15 +1492,14 @@ fn parse_diff_git_line(line: &str) -> Option<(&str, &str)> {
     Some((old_path, new_path))
 }
 
-fn untracked_file_patch(root: &Path, rel: &str) -> String {
-    let path = root.join(rel);
+fn untracked_file_patch(workspace_fs: &WorkspaceFs, rel: &str) -> String {
     let mut out = String::new();
     out.push_str(&format!("diff --git a/{rel} b/{rel}\n"));
     out.push_str("new file mode 100644\n");
     out.push_str("--- /dev/null\n");
     out.push_str(&format!("+++ b/{rel}\n"));
 
-    let bytes = match std::fs::read(&path) {
+    let bytes = match workspace_fs.read_content(rel) {
         Ok(bytes) => bytes,
         Err(e) => {
             out.push_str(&format!(

--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
 use std::{
-    fs,
     path::{Path, PathBuf},
     sync::{Arc, Mutex, MutexGuard},
 };
@@ -13,7 +12,8 @@ use tantivy::{
     Index, IndexReader, IndexWriter, TantivyDocument, TantivyError,
 };
 use tantivy_jieba::JiebaTokenizer;
-use walkdir::WalkDir;
+
+use crate::workspace_fs::WorkspaceFs;
 
 /// Query string for `GET /_/{workspace_id}/search?q=…`.
 #[derive(Deserialize)]
@@ -39,6 +39,7 @@ pub struct SearchIndex {
     field_title: Field,
     field_content: Field,
     start_dir: PathBuf,
+    workspace_fs: Arc<WorkspaceFs>,
 }
 
 impl SearchIndex {
@@ -46,7 +47,7 @@ impl SearchIndex {
     /// but which holds no documents yet. `start_dir` is the prefix that
     /// `rel_path` strips, so stored `path` values stay relative and consistent
     /// across [`Self::new`], [`Self::new_single_file`], and `update_file`.
-    fn empty(start_dir: &Path) -> tantivy::Result<Self> {
+    fn empty(workspace_fs: Arc<WorkspaceFs>) -> tantivy::Result<Self> {
         // Build schema
         let mut schema_builder = Schema::builder();
 
@@ -90,51 +91,35 @@ impl SearchIndex {
             field_file_name,
             field_title,
             field_content,
-            start_dir: start_dir.to_path_buf(),
+            start_dir: workspace_fs.ambient_root().to_path_buf(),
+            workspace_fs,
         })
     }
 
     pub fn new(start_dir: &Path) -> tantivy::Result<Self> {
-        let search_index = Self::empty(start_dir)?;
+        Self::for_workspace(Arc::new(WorkspaceFs::new(start_dir.to_path_buf(), None)))
+    }
+
+    pub(crate) fn for_workspace(workspace_fs: Arc<WorkspaceFs>) -> tantivy::Result<Self> {
+        let search_index = Self::empty(workspace_fs)?;
 
         // Index all markdown files
-        search_index.index_directory(start_dir)?;
+        search_index.index_workspace()?;
 
         Ok(search_index)
     }
 
     /// Build an index scoped to a SINGLE file inside `start_dir`.
     ///
-    /// Unlike [`Self::new`], this never walks `start_dir`: the resulting index
-    /// contains exactly one document — `start_dir/file_name` — so a single-file
-    /// workspace cannot leak sibling files through search. `start_dir` is still
-    /// the parent directory so the stored `path` is just `file_name`, matching
-    /// what the single-file watcher passes to `update_file` on later edits.
+    /// Unlike [`Self::new`], this constructs a single-file `WorkspaceFs`; the
+    /// shared indexer therefore sees exactly the pinned document and never
+    /// walks its parent. `start_dir` remains the stored path base so watcher
+    /// updates keep the same relative document key.
     pub fn new_single_file(start_dir: &Path, file_name: &str) -> tantivy::Result<Self> {
-        let search_index = Self::empty(start_dir)?;
-        search_index.index_single_file(file_name)?;
-        Ok(search_index)
-    }
-
-    /// Index exactly the pinned file (`start_dir/file_name`). Non-markdown or
-    /// unreadable targets leave the index empty rather than erroring, mirroring
-    /// the silent-skip behaviour of `index_directory`.
-    fn index_single_file(&self, file_name: &str) -> tantivy::Result<()> {
-        let path = self.start_dir.join(file_name);
-        tracing::info!("indexing single file {path:?}");
-
-        if path.extension().is_some_and(|ext| ext == "md") {
-            if let Ok(content) = fs::read_to_string(&path) {
-                let doc = self.build_document(&path, &content);
-                let mut writer = self.writer()?;
-                writer.add_document(doc)?;
-                writer.commit()?;
-            }
-        }
-
-        self.reader.reload()?;
-        tracing::info!("single-file indexing complete");
-        Ok(())
+        Self::for_workspace(Arc::new(WorkspaceFs::new(
+            start_dir.to_path_buf(),
+            Some(file_name),
+        )))
     }
 
     /// Acquire the writer lock, mapping poisoning to a tantivy error
@@ -147,16 +132,17 @@ impl SearchIndex {
         })
     }
 
-    fn index_directory(&self, dir: &Path) -> tantivy::Result<()> {
+    fn index_workspace(&self) -> tantivy::Result<()> {
         use rayon::prelude::*;
 
-        tracing::info!("indexing markdown files in {dir:?}");
+        tracing::info!("indexing markdown files in {:?}", self.start_dir);
 
-        let paths: Vec<PathBuf> = WalkDir::new(dir)
+        let paths: Vec<(String, PathBuf)> = self
+            .workspace_fs
+            .content_files(usize::MAX)
             .into_iter()
-            .filter_map(Result::ok)
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-            .map(|e| e.into_path())
+            .filter(|(rel, _)| rel.as_path().extension().is_some_and(|ext| ext == "md"))
+            .map(|(rel, path)| (rel.as_route(), path))
             .collect();
 
         // Stage 1: parallel CPU-bound work. Each worker reads its file
@@ -166,8 +152,8 @@ impl SearchIndex {
         // before.
         let docs: Vec<TantivyDocument> = paths
             .par_iter()
-            .filter_map(|path| {
-                let content = fs::read_to_string(path).ok()?;
+            .filter_map(|(rel, path)| {
+                let content = self.workspace_fs.read_content_to_string(rel).ok()?;
                 Some(self.build_document(path, &content))
             })
             .collect();
@@ -203,7 +189,10 @@ impl SearchIndex {
     /// work — does not touch the writer. Safe to call from rayon
     /// workers in parallel.
     fn build_document(&self, path: &Path, content: &str) -> TantivyDocument {
-        let relative_path = self.rel_path(path);
+        let relative_path = self
+            .workspace_fs
+            .route_for_path(path)
+            .unwrap_or_else(|| self.rel_path(path));
 
         let file_name = path
             .file_stem()
@@ -277,13 +266,23 @@ impl SearchIndex {
     }
 
     pub fn update_file(&self, path: &Path) -> tantivy::Result<()> {
-        if path.extension().is_none_or(|ext| ext != "md") {
+        let authorized = match self.workspace_fs.resolve_content_input(path) {
+            Ok(path) => path,
+            Err(_) => return Ok(()),
+        };
+        if authorized.extension().is_none_or(|ext| ext != "md") {
             return Ok(());
         }
 
-        let content = fs::read_to_string(path)?;
-        let doc = self.build_document(path, &content);
-        let relative_path = self.rel_path(path);
+        let relative_path = self
+            .workspace_fs
+            .route_for_path(&authorized)
+            .unwrap_or_else(|| self.rel_path(&authorized));
+        let content = match self.workspace_fs.read_content_to_string(&relative_path) {
+            Ok(content) => content,
+            Err(_) => return Ok(()),
+        };
+        let doc = self.build_document(&authorized, &content);
 
         // Delete and re-add in same transaction
         {
@@ -834,5 +833,30 @@ mod tests {
         );
         assert!(index.search("originaltoken", 10).unwrap().is_empty());
         assert_eq!(index.search("updatedtoken", 10).unwrap().len(), 1);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_directory_index_rejects_outside_symlink_on_build_and_update() {
+        use std::os::unix::fs::symlink;
+
+        let workspace = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        let secret = outside.path().join("secret.md");
+        fs::write(&secret, "uniquesymlinksecrettoken").unwrap();
+        let link = workspace.path().join("linked-secret.md");
+        symlink(&secret, &link).unwrap();
+
+        let index = SearchIndex::new(workspace.path()).unwrap();
+        assert!(index
+            .search("uniquesymlinksecrettoken", 10)
+            .unwrap()
+            .is_empty());
+
+        index.update_file(&link).unwrap();
+        assert!(index
+            .search("uniquesymlinksecrettoken", 10)
+            .unwrap()
+            .is_empty());
     }
 }

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -37,6 +37,7 @@ use crate::workspace::{
     ct_eq, expand_and_canonicalize, generate_token, ServerLock, WorkspaceConfig, WorkspaceEntry,
     WorkspaceEvent, WorkspaceFlags, WorkspaceRegistry,
 };
+use crate::workspace_fs::WorkspaceFs;
 
 const WORKSPACE_WS_ROUTE: &str = "/_/{workspace_id}/ws";
 
@@ -2718,8 +2719,9 @@ async fn handle_git_working_diff(
     };
     let can_manage = role.is_some_and(|Extension(role)| role == AccessRole::Admin);
     let initial_view = diff_view_from_query(query.view.as_deref());
-    let root = directory_root_or_not_found!(ws).to_path_buf();
-    let diff = tokio::task::spawn_blocking(move || git::working_diff(&root))
+    directory_root_or_not_found!(ws);
+    let workspace_fs = ws.fs.clone();
+    let diff = tokio::task::spawn_blocking(move || git::working_diff(&workspace_fs))
         .await
         .unwrap_or_else(|e| {
             tracing::error!("git working diff blocking task join error: {e}");
@@ -2747,10 +2749,11 @@ async fn handle_git_working_diff_data(
         return StatusCode::NOT_FOUND.into_response();
     };
     if diff_view_from_query(query.view.as_deref()) == "rendered" {
+        directory_root_or_not_found!(ws);
         return match markdown_compare_diff_data_async(
             &state,
             &workspace_id,
-            directory_root_or_not_found!(ws),
+            ws.fs.clone(),
             "HEAD",
             "worktree",
             query.f.as_deref(),
@@ -2769,8 +2772,9 @@ async fn handle_git_working_diff_data(
                 .into_response(),
         };
     }
-    let root = directory_root_or_not_found!(ws).to_path_buf();
-    let diff = tokio::task::spawn_blocking(move || git::working_diff(&root))
+    directory_root_or_not_found!(ws);
+    let workspace_fs = ws.fs.clone();
+    let diff = tokio::task::spawn_blocking(move || git::working_diff(&workspace_fs))
         .await
         .unwrap_or_else(|e| {
             tracing::error!("git working diff blocking task join error: {e}");
@@ -2888,10 +2892,11 @@ async fn handle_pretty_compare_diff(
     let can_manage = role.is_some_and(|Extension(role)| role == AccessRole::Admin);
     let initial_view = diff_view_from_query(query.view.as_deref());
     if query.format.as_deref() == Some("data") && initial_view == "rendered" {
+        directory_root_or_not_found!(ws);
         return match markdown_compare_diff_data_async(
             &state,
             &workspace_id,
-            directory_root_or_not_found!(ws),
+            ws.fs.clone(),
             &base,
             &compare,
             query.f.as_deref(),
@@ -2910,7 +2915,8 @@ async fn handle_pretty_compare_diff(
                 .into_response(),
         };
     }
-    match git::compare_diff(directory_root_or_not_found!(ws), &base, &compare) {
+    directory_root_or_not_found!(ws);
+    match git::compare_diff(&ws.fs, &base, &compare) {
         Ok(diff) if query.format.as_deref() == Some("data") => {
             git_diff_json_response(&diff, query.f.as_deref())
         }
@@ -5232,15 +5238,18 @@ struct MarkdownBuildItem<'a> {
 fn markdown_compare_diff_data(
     state: &AppState,
     workspace_id: &str,
-    root: &FsPath,
+    workspace_fs: &WorkspaceFs,
     base: &str,
     compare: &str,
     file_filter: Option<&str>,
 ) -> git::Result<MarkdownDiffData> {
+    let root = workspace_fs
+        .directory_root()
+        .ok_or_else(|| git::GitError::Io("directory workspace required".to_string()))?;
     let engine = markdown_ast::engine_info();
     // Cheap enumeration: `git diff --raw` (no patch) + untracked md. Gives each
     // changed file's status and per-side blob oids without reading content.
-    let listing = git::markdown_diff_listing(root, base, compare)?;
+    let listing = git::markdown_diff_listing(workspace_fs, base, compare)?;
     if !engine.enabled {
         return Ok(MarkdownDiffData {
             title: "Markdown visual diff".to_string(),
@@ -5283,7 +5292,7 @@ fn markdown_compare_diff_data(
         } else if let Some(blob) = &entry.new_blob {
             Some(blob.clone())
         } else {
-            match fs::read_to_string(root.join(&entry.path)) {
+            match workspace_fs.read_content_to_string(&entry.path) {
                 Ok(content) => {
                     let id = format!("h:{}", markdown_content_hash(&content));
                     new_worktree = Some(content);
@@ -5364,7 +5373,7 @@ fn markdown_compare_diff_data(
         .map(|(i, item)| {
             (
                 i,
-                build_markdown_diff_file(state, workspace_id, item, &blobs, root),
+                build_markdown_diff_file(state, workspace_id, item, &blobs, workspace_fs),
             )
         })
         .collect();
@@ -5409,14 +5418,13 @@ fn markdown_compare_diff_data(
 async fn markdown_compare_diff_data_async(
     state: &AppState,
     workspace_id: &str,
-    root: &FsPath,
+    workspace_fs: Arc<WorkspaceFs>,
     base: &str,
     compare: &str,
     file_filter: Option<&str>,
 ) -> git::Result<MarkdownDiffData> {
     let state = state.clone();
     let workspace_id = workspace_id.to_string();
-    let root = root.to_path_buf();
     let base = base.to_string();
     let compare = compare.to_string();
     let file_filter = file_filter.map(str::to_string);
@@ -5424,7 +5432,7 @@ async fn markdown_compare_diff_data_async(
         markdown_compare_diff_data(
             &state,
             &workspace_id,
-            &root,
+            &workspace_fs,
             &base,
             &compare,
             file_filter.as_deref(),
@@ -5444,9 +5452,12 @@ fn build_markdown_diff_file(
     workspace_id: &str,
     item: &MarkdownBuildItem,
     blobs: &HashMap<String, Vec<u8>>,
-    root: &FsPath,
+    workspace_fs: &WorkspaceFs,
 ) -> MarkdownDiffFile {
     let entry = item.entry;
+    let root = workspace_fs
+        .directory_root()
+        .expect("markdown diff requires a directory workspace");
     // Canonicalize the new-side path the same way `render_markdown_file` builds
     // its `file_path` key, so a highlight made in the diff binds to the same
     // annotation row as one made in the normal file view. `entry.path` is
@@ -5457,8 +5468,9 @@ fn build_markdown_diff_file(
     // back to the lexical join (such files are not annotatable anyway).
     let abs_path = {
         let joined = root.join(&entry.path);
-        canonicalize_route_path(&joined)
-            .map(|p| p.to_string_lossy().into_owned())
+        workspace_fs
+            .resolve_content(&entry.path)
+            .map(|path| path.to_string_lossy().into_owned())
             .unwrap_or_else(|_| joined.to_string_lossy().into_owned())
     };
     let mut diagnostics = item.read_diagnostics.clone();
@@ -9171,11 +9183,12 @@ mod tests {
 
         let registry = Arc::new(WorkspaceRegistry::new("git-cache-test".into()));
         let state = test_state(registry);
+        let workspace_fs = WorkspaceFs::new(dir.path().to_path_buf(), None);
 
         let first = markdown_compare_diff_data(
             &state,
             "git-cache-test",
-            dir.path(),
+            &workspace_fs,
             "HEAD",
             "worktree",
             Some("a.md"),
@@ -9202,7 +9215,7 @@ mod tests {
         let second = markdown_compare_diff_data(
             &state,
             "git-cache-test",
-            dir.path(),
+            &workspace_fs,
             "HEAD",
             "worktree",
             Some("a.md"),
@@ -9219,7 +9232,7 @@ mod tests {
         let third = markdown_compare_diff_data(
             &state,
             "git-cache-test",
-            dir.path(),
+            &workspace_fs,
             "HEAD",
             "worktree",
             Some("a.md"),
@@ -9276,8 +9289,9 @@ mod tests {
 
         let registry = Arc::new(WorkspaceRegistry::new("asset-diff-test".into()));
         let state = test_state(registry);
+        let workspace_fs = WorkspaceFs::new(dir.path().to_path_buf(), None);
         let data =
-            markdown_compare_diff_data(&state, "asset-ws", dir.path(), "HEAD", "worktree", None)
+            markdown_compare_diff_data(&state, "asset-ws", &workspace_fs, "HEAD", "worktree", None)
                 .unwrap();
 
         for folder in ["docs", "guide"] {
@@ -9336,12 +9350,13 @@ mod tests {
 
         let registry = Arc::new(WorkspaceRegistry::new("subdir-abs-test".into()));
         let state = test_state(registry);
+        let workspace_fs = WorkspaceFs::new(ws_root.clone(), None);
 
         // Pass the SUBDIRECTORY as the workspace root, exactly as the route would.
         let data = markdown_compare_diff_data(
             &state,
             "subdir-abs-test",
-            &ws_root,
+            &workspace_fs,
             "HEAD",
             "worktree",
             None,
@@ -9383,6 +9398,58 @@ mod tests {
             "tracked new side must load in a subdir workspace"
         );
         assert!(json.contains("Brand new"), "untracked new side must load");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rendered_markdown_diff_does_not_read_untracked_outside_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let repo = tempfile::tempdir().unwrap();
+        let outside = tempfile::NamedTempFile::new().unwrap();
+        fs::write(outside.path(), "OUTSIDE SECRET MARKER").unwrap();
+        fs::write(repo.path().join("README.md"), "# tracked").unwrap();
+        let git = |args: &[&str]| {
+            let output = std::process::Command::new("git")
+                .arg("-C")
+                .arg(repo.path())
+                .args(args)
+                .output()
+                .unwrap();
+            assert!(output.status.success(), "git {args:?} failed");
+        };
+        git(&["init"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "Test User"]);
+        git(&["add", "README.md"]);
+        git(&["commit", "-m", "initial"]);
+        symlink(outside.path(), repo.path().join("leak.md")).unwrap();
+
+        let state = test_state(Arc::new(WorkspaceRegistry::new("symlink-diff-test".into())));
+        let workspace_fs = WorkspaceFs::new(repo.path().to_path_buf(), None);
+        let raw = git::working_diff(&workspace_fs).unwrap();
+        assert!(!raw.patch.contains("OUTSIDE SECRET MARKER"));
+        let compare = git::compare_diff(&workspace_fs, "HEAD", "worktree").unwrap();
+        assert!(!compare.patch.contains("OUTSIDE SECRET MARKER"));
+        let data = markdown_compare_diff_data(
+            &state,
+            "symlink-diff-test",
+            &workspace_fs,
+            "HEAD",
+            "worktree",
+            None,
+        )
+        .unwrap();
+        let entry = data
+            .files
+            .iter()
+            .find(|file| file.path == "leak.md")
+            .expect("untracked markdown symlink must exercise the diff path");
+        assert!(entry.new_source.is_none());
+        assert_eq!(entry.additions, 0);
+        assert!(!serde_json::to_string(&data)
+            .unwrap()
+            .contains("OUTSIDE SECRET MARKER"));
     }
 
     #[tokio::test]

--- a/crates/core/src/workspace.rs
+++ b/crates/core/src/workspace.rs
@@ -404,17 +404,13 @@ impl WorkspaceRegistry {
                 // sibling leakage); the single-file watcher refreshes it on edit.
                 refresh_allowed_assets(&entry, &name);
                 if config.flags.enable_search {
-                    spawn_single_file_search_indexer(
-                        config.path.clone(),
-                        entry.clone(),
-                        name.clone(),
-                    );
+                    spawn_search_indexer(entry.clone());
                 }
                 spawn_single_file_watcher(config.path, entry.clone(), name);
             }
             None => {
                 if config.flags.enable_search {
-                    spawn_search_indexer(config.path.clone(), entry.clone());
+                    spawn_search_indexer(entry.clone());
                 }
                 spawn_directory_watcher(config.path, entry.clone());
             }
@@ -451,11 +447,7 @@ impl WorkspaceRegistry {
         // workspaces: turning search on spawns the appropriate indexer, turning
         // it off drops the index so we stop serving stale results and free RAM.
         if flags.enable_search && !was_search && entry.search_index.load().is_none() {
-            let root = entry.fs.ambient_root().to_path_buf();
-            match &entry.single_file {
-                Some(name) => spawn_single_file_search_indexer(root, entry.clone(), name.clone()),
-                None => spawn_search_indexer(root, entry),
-            }
+            spawn_search_indexer(entry);
         } else if !flags.enable_search && was_search {
             entry.search_index.store(None);
         }
@@ -658,9 +650,9 @@ fn spawn_single_file_watcher(root: PathBuf, entry: Arc<WorkspaceEntry>, file_nam
     );
 }
 
-fn spawn_search_indexer(root: PathBuf, entry: Arc<WorkspaceEntry>) {
+fn spawn_search_indexer(entry: Arc<WorkspaceEntry>) {
     std::thread::spawn(move || {
-        if let Ok(idx) = SearchIndex::new(&root) {
+        if let Ok(idx) = SearchIndex::for_workspace(entry.fs.clone()) {
             entry.search_index.store(Some(Arc::new(idx)));
         }
     });
@@ -719,19 +711,6 @@ fn directory_live_reload_path(root: &Path, path: &Path) -> Option<String> {
         return None;
     }
     Some(path_to_forward_slash(rel))
-}
-
-/// Build a search index scoped to a single-file workspace's pinned file and
-/// store it on the entry. Unlike [`spawn_search_indexer`], this indexes only
-/// `root/file_name` (no WalkDir of the parent → no sibling leakage) and spawns
-/// no extra file watcher: the single-file watcher already owns the parent dir
-/// and refreshes this index on edit via `entry.search_index`.
-fn spawn_single_file_search_indexer(root: PathBuf, entry: Arc<WorkspaceEntry>, file_name: String) {
-    std::thread::spawn(move || {
-        if let Ok(idx) = SearchIndex::new_single_file(&root, &file_name) {
-            entry.search_index.store(Some(Arc::new(idx)));
-        }
-    });
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]

--- a/crates/core/src/workspace_fs.rs
+++ b/crates/core/src/workspace_fs.rs
@@ -196,16 +196,31 @@ impl WorkspaceFs {
         rel: impl AsRef<Path>,
     ) -> Result<PathBuf, WorkspaceFsError> {
         let route = WorkspaceRelPath::parse(rel)?;
-        match &self.scope {
-            WorkspaceScope::Directory => {
-                let target = self.canonicalize_rel(&route)?;
-                Ok(self.absolute(&target))
-            }
-            WorkspaceScope::SingleFile { document, .. } if route == document.route => {
-                self.resolve_scoped(&route, &document.target)
-            }
-            WorkspaceScope::SingleFile { .. } => Err(WorkspaceFsError::Denied),
-        }
+        let target = self.content_target(&route)?;
+        Ok(self.absolute(&target))
+    }
+
+    /// Read through the capability handle after applying the same content
+    /// policy as [`Self::resolve_content`]. This keeps bulk/high-level features
+    /// from re-opening an authorized ambient path and reintroducing a symlink
+    /// race between validation and I/O.
+    pub(crate) fn read_content(&self, rel: impl AsRef<Path>) -> Result<Vec<u8>, WorkspaceFsError> {
+        let route = WorkspaceRelPath::parse(rel)?;
+        let target = self.content_target(&route)?;
+        self.root_dir()?
+            .read(target.as_path())
+            .map_err(map_io_error)
+    }
+
+    pub(crate) fn read_content_to_string(
+        &self,
+        rel: impl AsRef<Path>,
+    ) -> Result<String, WorkspaceFsError> {
+        let route = WorkspaceRelPath::parse(rel)?;
+        let target = self.content_target(&route)?;
+        self.root_dir()?
+            .read_to_string(target.as_path())
+            .map_err(map_io_error)
     }
 
     /// Resolve either a workspace-relative route or an absolute path supplied
@@ -239,7 +254,12 @@ impl WorkspaceFs {
     }
 
     pub(crate) fn route_for_path(&self, path: &Path) -> Option<String> {
-        let rel = path.strip_prefix(&self.canonical_root).ok()?;
+        // Callers may hand us a lexical path produced by a directory walk. A
+        // symlink under the workspace can still target an ambient file outside
+        // it, so containment must be checked after resolution, not just with a
+        // lexical `strip_prefix`.
+        let canonical = dunce::canonicalize(path).ok()?;
+        let rel = canonical.strip_prefix(&self.canonical_root).ok()?;
         let target = WorkspaceRelPath::parse(rel).ok()?;
         match &self.scope {
             WorkspaceScope::SingleFile { document, .. } if target == document.target => {
@@ -302,8 +322,18 @@ impl WorkspaceFs {
             .filter(|entry| entry.path().is_file())
             .filter_map(|entry| {
                 let rel = entry.path().strip_prefix(&self.canonical_root).ok()?;
-                let rel = WorkspaceRelPath::parse(rel).ok()?;
-                allow(&rel).then(|| (rel, entry.into_path()))
+                let route = WorkspaceRelPath::parse(rel).ok()?;
+                if !allow(&route) {
+                    return None;
+                }
+                // `ignore::DirEntry::path().is_file()` follows symlinks. Always
+                // re-resolve through the capability before returning an ambient
+                // path, otherwise bulk consumers (grep/glob/file listings) could
+                // read a symlink target outside the workspace even though the
+                // point resolver correctly rejects it.
+                let target = self.canonicalize_rel(&route).ok()?;
+                let absolute = self.absolute(&target);
+                absolute.is_file().then_some((route, absolute))
             })
             .take(limit)
             .collect()
@@ -313,18 +343,28 @@ impl WorkspaceFs {
         &self,
         rel: &WorkspaceRelPath,
     ) -> Result<WorkspaceRelPath, WorkspaceFsError> {
-        let root = self
-            .root
-            .as_ref()
-            .ok_or_else(|| WorkspaceFsError::Io("workspace root is not open".to_string()))?;
-        let canonical = root
-            .canonicalize(rel.as_path())
-            .map_err(|error| match error.kind() {
-                std::io::ErrorKind::NotFound => WorkspaceFsError::NotFound,
-                std::io::ErrorKind::PermissionDenied => WorkspaceFsError::Denied,
-                _ => WorkspaceFsError::Io(error.to_string()),
-            })?;
+        let root = self.root_dir()?;
+        let canonical = root.canonicalize(rel.as_path()).map_err(map_io_error)?;
         WorkspaceRelPath::parse(canonical)
+    }
+
+    fn root_dir(&self) -> Result<&Dir, WorkspaceFsError> {
+        self.root
+            .as_deref()
+            .ok_or_else(|| WorkspaceFsError::Io("workspace root is not open".to_string()))
+    }
+
+    fn content_target(
+        &self,
+        route: &WorkspaceRelPath,
+    ) -> Result<WorkspaceRelPath, WorkspaceFsError> {
+        match &self.scope {
+            WorkspaceScope::Directory => self.canonicalize_rel(route),
+            WorkspaceScope::SingleFile { document, .. } if route == &document.route => {
+                self.scoped_target(route, &document.target)
+            }
+            WorkspaceScope::SingleFile { .. } => Err(WorkspaceFsError::Denied),
+        }
     }
 
     fn resolve_scoped(
@@ -332,15 +372,32 @@ impl WorkspaceFs {
         route: &WorkspaceRelPath,
         expected_target: &WorkspaceRelPath,
     ) -> Result<PathBuf, WorkspaceFsError> {
+        let current_target = self.scoped_target(route, expected_target)?;
+        Ok(self.absolute(&current_target))
+    }
+
+    fn scoped_target(
+        &self,
+        route: &WorkspaceRelPath,
+        expected_target: &WorkspaceRelPath,
+    ) -> Result<WorkspaceRelPath, WorkspaceFsError> {
         let current_target = self.canonicalize_rel(route)?;
         if &current_target != expected_target {
             return Err(WorkspaceFsError::Denied);
         }
-        Ok(self.absolute(&current_target))
+        Ok(current_target)
     }
 
     fn absolute(&self, rel: &WorkspaceRelPath) -> PathBuf {
         self.canonical_root.join(rel.as_path())
+    }
+}
+
+fn map_io_error(error: std::io::Error) -> WorkspaceFsError {
+    match error.kind() {
+        std::io::ErrorKind::NotFound => WorkspaceFsError::NotFound,
+        std::io::ErrorKind::PermissionDenied => WorkspaceFsError::Denied,
+        _ => WorkspaceFsError::Io(error.to_string()),
     }
 }
 
@@ -387,6 +444,40 @@ mod tests {
         ));
         #[cfg(unix)]
         assert!(fs.resolve_content("escape/secret.md").is_err());
+    }
+
+    #[test]
+    fn bulk_enumeration_rejects_outside_file_symlink() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let outside = tempfile::TempDir::new().unwrap();
+        std::fs::write(temp.path().join("inside.md"), "inside").unwrap();
+        let secret = outside.path().join("secret.md");
+        std::fs::write(&secret, "secret").unwrap();
+        let link = temp.path().join("linked-secret.md");
+
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&secret, &link).unwrap();
+        #[cfg(windows)]
+        if std::os::windows::fs::symlink_file(&secret, &link).is_err() {
+            // Windows requires Developer Mode or elevated symlink privilege.
+            return;
+        }
+
+        let fs = WorkspaceFs::new(temp.path().to_path_buf(), None);
+        let content_routes: Vec<_> = fs
+            .content_files(10)
+            .into_iter()
+            .map(|(rel, _)| rel.as_route())
+            .collect();
+        let served_routes: Vec<_> = fs
+            .served_files(10)
+            .into_iter()
+            .map(|(rel, _)| rel.as_route())
+            .collect();
+
+        assert_eq!(content_routes, ["inside.md"]);
+        assert_eq!(served_routes, ["inside.md"]);
+        assert!(fs.route_for_path(&link).is_none());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- route bulk file enumeration through `WorkspaceFs` canonical capability checks
- add capability-handle reads so high-level consumers do not reopen ambient paths after authorization
- make initial and incremental search indexing consume the workspace capability
- make raw and rendered Git worktree diffs use capability-scoped reads for untracked files
- filter Chat directory listings and file tools through the same resolved boundary
- bump the workspace to 0.15.13 because v0.15.12-rc.1 already points at the preceding security tree

## Root cause

The first security refactor correctly centralized point-path authorization, but a post-merge adversarial review found that several bulk consumers still walked the ambient directory and reopened returned `PathBuf`s. An in-workspace symlink to an external file could therefore be skipped by point resolution yet consumed by search, Chat enumeration, or Git diff generation.

This change makes `WorkspaceFs` the choke point for both enumeration and content reads, then passes that same capability into Search and Git rather than reconstructing authorization from a root path.

## Impact

- external symlink targets are excluded from served/content enumerations
- initial search indexing and watcher updates cannot ingest external symlink content
- Chat list/glob/grep cannot expose external symlink targets
- raw and rendered Git diffs cannot read an untracked external symlink target
- the workspace ID algorithm, settings format, SQLite schema, and absolute annotation keys are unchanged

## Validation

- local canonical quality gate: full-feature Clippy, 325 Rust tests, 462 browser tests, lint, formatting, and Graphviz static-link policy
- `cargo publish --dry-run -p markon-core --allow-dirty` for 0.15.13
- s67 macOS: 304 markon-core tests, full-feature Clippy, Graphviz static policy
- s68 Linux: 304 markon-core tests, full-feature Clippy, Graphviz static policy
- s69 Windows: 298 markon-core tests and full-feature Clippy; Windows symlink capability test executed successfully
