### PR TITLE
ci: rename TypeScript check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,8 +140,8 @@ jobs:
       - name: Verify generated icons are up to date
         run: cargo xtask icons --check
 
-  js:
-    name: JS Tests & Lint
+  ts:
+    name: TS Tests & Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- rename the browser-source CI job id from `js` to `ts`
- rename the required check from `JS Tests & Lint` to `TS Tests & Lint`
- align CI terminology with the TypeScript-only browser source policy

## Validation
- parsed `.github/workflows/ci.yml` as YAML
- ran `git diff --check`

After GitHub publishes the new check context, the `main` branch protection rule will be updated from the obsolete `ESLint` context to `TS Tests & Lint`.