### PR TITLE
fix: review security batch — raw-HTML XSS, access-code hash, preview guard

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -990,6 +990,12 @@ async fn main() {
             settings.salt.clone()
         }
     });
+    if let Some(code) = cli.collaborator_access_code.as_deref() {
+        if let Err(e) = markon_core::workspace::validate_access_code(code) {
+            eprintln!("Error: {e}");
+            std::process::exit(1);
+        }
+    }
     let workspace_collaborator_access_code_hash =
         resolve_workspace_collaborator_hash_from_env_or_cli(
             saved_workspace

--- a/crates/core/assets/js/managers/editor-manager.test.ts
+++ b/crates/core/assets/js/managers/editor-manager.test.ts
@@ -201,8 +201,10 @@ describe('EditorManager', () => {
 
     it('preview path uses server-rendered diagram HTML without client Mermaid', async () => {
         seedOriginalMarkdown('```mermaid\ngraph TD; A-->B\n```');
+        seedMeta('workspace-id', 'ws-42');
+        seedMeta('preview-token', 'preview-abc');
 
-        const fetchMock = vi.fn(async (url: string) => {
+        const fetchMock = vi.fn(async (url: string, _init?: RequestInit) => {
             if (url === '/api/preview') {
                 return {
                     ok: true,
@@ -232,5 +234,16 @@ describe('EditorManager', () => {
         await Promise.resolve();
 
         expect(document.querySelector('.markon-diagram svg')).toBeTruthy();
+        const previewCalls = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+            (c: unknown[]) => c[0] === '/api/preview',
+        );
+        expect(previewCalls.length).toBeGreaterThan(0);
+        const init = itemAt(previewCalls, 0)[1] as RequestInit;
+        const headers = init.headers as Record<string, string>;
+        expect(headers['X-Markon-Token']).toBe('preview-abc');
+        expect(JSON.parse(init.body as string)).toEqual({
+            workspace_id: 'ws-42',
+            content: '```mermaid\ngraph TD; A-->B\n```',
+        });
     });
 });

--- a/crates/core/assets/js/managers/editor-manager.ts
+++ b/crates/core/assets/js/managers/editor-manager.ts
@@ -63,6 +63,12 @@ export interface EditorSaveResponse {
     message?: string;
 }
 
+/** Request body sent to POST /api/preview. */
+export interface EditorPreviewRequest {
+    workspace_id: string;
+    content: string;
+}
+
 /** Response shape from POST /api/preview. */
 export interface EditorPreviewResponse {
     html: string;
@@ -801,11 +807,20 @@ export class EditorManager {
         if (!this.#previewPane || !this.#textarea) return;
 
         const content = this.#textarea.value;
+        const workspaceId = Meta.get(CONFIG.META_TAGS.WORKSPACE_ID) ?? '';
+        const token = Meta.get('preview-token') ?? '';
+        const body: EditorPreviewRequest = {
+            workspace_id: workspaceId,
+            content,
+        };
         try {
             const response = await fetch('/api/preview', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ content }),
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Markon-Token': token,
+                },
+                body: JSON.stringify(body),
             });
             if (!response.ok) return;
             const result = (await response.json()) as EditorPreviewResponse;

--- a/crates/core/assets/templates/git-diff.html
+++ b/crates/core/assets/templates/git-diff.html
@@ -12,6 +12,7 @@
     <meta name="enable-viewed" content="false">
     <meta name="enable-search" content="false">
     <meta name="enable-edit" content="false">
+    <meta name="preview-token" content="{{ preview_token }}">
     <meta name="enable-live" content="{{ enable_live }}">
     <meta name="enable-chat" content="{{ enable_chat }}">
     <meta name="default-chat-mode" content="{{ default_chat_mode }}">

--- a/crates/core/assets/templates/layout.html
+++ b/crates/core/assets/templates/layout.html
@@ -11,6 +11,7 @@
     <meta name="enable-viewed" content="{{ enable_viewed }}">
     <meta name="enable-search" content="{{ enable_search }}">
     <meta name="enable-edit" content="{{ enable_edit }}">
+    <meta name="preview-token" content="{{ preview_token }}">
     {% if save_token %}<meta name="save-token" content="{{ save_token }}">{% endif %}
     <meta name="enable-live" content="{{ enable_live }}">
     <meta name="enable-chat" content="{{ enable_chat }}">

--- a/crates/core/src/markdown.rs
+++ b/crates/core/src/markdown.rs
@@ -1163,15 +1163,22 @@ impl MarkdownRenderer {
                 children,
                 ..
             } => {
-                out.push_str("<a href=\"");
-                html_escape::encode_double_quoted_attribute_to_string(url, out);
-                out.push('"');
-                if let Some(title) = title {
-                    out.push_str(" title=\"");
-                    html_escape::encode_double_quoted_attribute_to_string(title, out);
+                // Drop the href for unsafe schemes (javascript:, data:, …) so a
+                // `[text](javascript:…)` link renders as inert text, not a click
+                // that executes script.
+                if url_scheme_is_safe(url, false) {
+                    out.push_str("<a href=\"");
+                    html_escape::encode_double_quoted_attribute_to_string(url, out);
                     out.push('"');
+                    if let Some(title) = title {
+                        out.push_str(" title=\"");
+                        html_escape::encode_double_quoted_attribute_to_string(title, out);
+                        out.push('"');
+                    }
+                    out.push('>');
+                } else {
+                    out.push_str("<a>");
                 }
-                out.push('>');
                 self.render_nodes(children, out, ctx);
                 out.push_str("</a>");
             }
@@ -1180,17 +1187,25 @@ impl MarkdownRenderer {
             } => {
                 let rewritten_url = self.rewrite_image_url(url);
                 let src = rewritten_url.as_deref().unwrap_or(url);
-                out.push_str("<img src=\"");
-                html_escape::encode_double_quoted_attribute_to_string(src, out);
-                out.push_str("\" alt=\"");
-                html_escape::encode_double_quoted_attribute_to_string(alt, out);
-                out.push('"');
-                if let Some(title) = title {
-                    out.push_str(" title=\"");
-                    html_escape::encode_double_quoted_attribute_to_string(title, out);
+                // Images may carry `data:image/…`; any other non-safe scheme is
+                // dropped, leaving the alt text.
+                if url_scheme_is_safe(src, true) {
+                    out.push_str("<img src=\"");
+                    html_escape::encode_double_quoted_attribute_to_string(src, out);
+                    out.push_str("\" alt=\"");
+                    html_escape::encode_double_quoted_attribute_to_string(alt, out);
                     out.push('"');
+                    if let Some(title) = title {
+                        out.push_str(" title=\"");
+                        html_escape::encode_double_quoted_attribute_to_string(title, out);
+                        out.push('"');
+                    }
+                    out.push_str(" />");
+                } else {
+                    out.push_str("<img alt=\"");
+                    html_escape::encode_double_quoted_attribute_to_string(alt, out);
+                    out.push_str("\" />");
                 }
-                out.push_str(" />");
             }
             SupramarkNode::Break { .. } => out.push_str("<br />\n"),
             SupramarkNode::Delete { children, .. } => {
@@ -1370,7 +1385,7 @@ impl MarkdownRenderer {
                 ..
             } => {
                 if format.eq_ignore_ascii_case("html") {
-                    out.push_str(value);
+                    out.push_str(&sanitize_raw_html_fragment(value));
                     if *block {
                         out.push('\n');
                     }
@@ -1770,6 +1785,295 @@ fn strip_html_tags(value: &str) -> String {
     out
 }
 
+/// Tags that may survive from *author-written raw HTML* (the `raw-html` feature
+/// passes inline HTML through the AST as `Raw{format:"html"}` fragments). This
+/// is a deliberately small GitHub-flavored formatting/structure set; anything
+/// outside it is escaped to inert text. It does NOT need to list markon's own
+/// generated markup (octicon SVGs, syntect spans, diagram/math containers,
+/// heading anchors …) because that markup never passes through this scrubber —
+/// only untrusted raw fragments do — so there is no risk of silently dropping
+/// first-party markup.
+const RAW_HTML_ALLOWED_TAGS: &[&str] = &[
+    "a", "abbr", "b", "bdi", "bdo", "blockquote", "br", "caption", "cite",
+    "code", "col", "colgroup", "dd", "del", "details", "dfn", "div", "dl", "dt",
+    "em", "figcaption", "figure", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i",
+    "img", "ins", "kbd", "li", "mark", "ol", "p", "pre", "q", "rp", "rt", "ruby",
+    "s", "samp", "small", "span", "strong", "sub", "summary", "sup", "table",
+    "tbody", "td", "tfoot", "th", "thead", "time", "tr", "u", "ul", "var", "wbr",
+];
+
+/// Attributes whose value carries a URL and must pass [`url_scheme_is_safe`].
+const RAW_HTML_URL_ATTRS: &[&str] = &[
+    "href",
+    "src",
+    "xlink:href",
+    "action",
+    "formaction",
+    "poster",
+    "background",
+    "srcset",
+    "ping",
+    "data",
+];
+
+/// Sanitize one author-written raw HTML fragment WITHOUT rebalancing tags.
+///
+/// The markdown parser hands raw HTML through split into open/close fragments
+/// (`<details>` and `</details>` arrive as separate `Raw` nodes with rendered
+/// markdown in between), so a tree-rebuilding sanitizer (ammonia/html5ever)
+/// would prematurely close `<details>`/`<div>` wrappers and drop the stray
+/// closing tags — breaking legitimate GitHub-style inline HTML. Instead we scan
+/// tag-by-tag and rewrite in place, fail-closed: a tag we can't parse cleanly,
+/// or whose name isn't in [`RAW_HTML_ALLOWED_TAGS`], is escaped to visible text
+/// rather than emitted. On allowed tags we strip event-handler (`on*`) and
+/// `style`/`srcdoc` attributes and drop URL attributes with an unsafe scheme.
+fn sanitize_raw_html_fragment(frag: &str) -> String {
+    let bytes = frag.as_bytes();
+    let mut out = String::with_capacity(frag.len() + 16);
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'<' {
+            if let Some((end, rendered)) = sanitize_html_tag(frag, i) {
+                out.push_str(&rendered);
+                i = end;
+            } else {
+                // Not a well-formed tag → the '<' is literal text.
+                out.push_str("&lt;");
+                i += 1;
+            }
+            continue;
+        }
+        let start = i;
+        while i < bytes.len() && bytes[i] != b'<' {
+            i += 1;
+        }
+        out.push_str(&frag[start..i]);
+    }
+    out
+}
+
+fn escape_html_text(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    html_escape::encode_text_to_string(s, &mut out);
+    out
+}
+
+/// Parse a single tag starting at `start` (`frag[start] == '<'`). Returns the
+/// index just past the tag and the sanitized replacement, or `None` when the
+/// bytes aren't a well-formed tag (the caller then escapes the lone `<`).
+fn sanitize_html_tag(frag: &str, start: usize) -> Option<(usize, String)> {
+    let bytes = frag.as_bytes();
+    let rest = &frag[start..];
+
+    // Comments: drop entirely (fail closed on an unterminated one).
+    if rest.starts_with("<!--") {
+        return match rest.find("-->") {
+            Some(pos) => Some((start + pos + 3, String::new())),
+            None => Some((frag.len(), String::new())),
+        };
+    }
+    // Doctype / CDATA / processing instructions: not expected inside a fragment.
+    if rest.starts_with("<!") || rest.starts_with("<?") {
+        return None;
+    }
+
+    let mut i = start + 1;
+    let closing = i < bytes.len() && bytes[i] == b'/';
+    if closing {
+        i += 1;
+    }
+
+    // Tag name: must start with a letter.
+    let name_start = i;
+    while i < bytes.len() && (bytes[i].is_ascii_alphanumeric() || bytes[i] == b'-') {
+        i += 1;
+    }
+    if i == name_start || !bytes[name_start].is_ascii_alphabetic() {
+        return None;
+    }
+    let name = frag[name_start..i].to_ascii_lowercase();
+    let allowed = RAW_HTML_ALLOWED_TAGS.contains(&name.as_str());
+
+    if closing {
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= bytes.len() || bytes[i] != b'>' {
+            return None;
+        }
+        let end = i + 1;
+        return Some((
+            end,
+            if allowed {
+                format!("</{name}>")
+            } else {
+                escape_html_text(&frag[start..end])
+            },
+        ));
+    }
+
+    // Opening / self-closing tag: parse attributes, honoring quoted values so a
+    // '>' inside a value doesn't end the tag early.
+    let mut attrs: Vec<(String, Option<String>)> = Vec::new();
+    loop {
+        while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i >= bytes.len() {
+            return None; // no closing '>'
+        }
+        match bytes[i] {
+            b'>' => {
+                i += 1;
+                break;
+            }
+            b'/' => {
+                i += 1;
+                while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+                    i += 1;
+                }
+                if i < bytes.len() && bytes[i] == b'>' {
+                    i += 1;
+                    break;
+                }
+                return None;
+            }
+            _ => {
+                let an_start = i;
+                while i < bytes.len() {
+                    let b = bytes[i];
+                    if b.is_ascii_whitespace() || b == b'=' || b == b'>' || b == b'/' {
+                        break;
+                    }
+                    i += 1;
+                }
+                if i == an_start {
+                    return None;
+                }
+                let aname = frag[an_start..i].to_ascii_lowercase();
+                while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+                    i += 1;
+                }
+                let mut aval: Option<String> = None;
+                if i < bytes.len() && bytes[i] == b'=' {
+                    i += 1;
+                    while i < bytes.len() && bytes[i].is_ascii_whitespace() {
+                        i += 1;
+                    }
+                    if i >= bytes.len() {
+                        return None;
+                    }
+                    let quote = bytes[i];
+                    if quote == b'"' || quote == b'\'' {
+                        i += 1;
+                        let v_start = i;
+                        while i < bytes.len() && bytes[i] != quote {
+                            i += 1;
+                        }
+                        if i >= bytes.len() {
+                            return None; // unterminated quote
+                        }
+                        aval = Some(frag[v_start..i].to_string());
+                        i += 1;
+                    } else {
+                        let v_start = i;
+                        while i < bytes.len() {
+                            let b = bytes[i];
+                            if b.is_ascii_whitespace() || b == b'>' {
+                                break;
+                            }
+                            i += 1;
+                        }
+                        aval = Some(frag[v_start..i].to_string());
+                    }
+                }
+                attrs.push((aname, aval));
+            }
+        }
+    }
+    let end = i;
+
+    if !allowed {
+        return Some((end, escape_html_text(&frag[start..end])));
+    }
+
+    let allow_data_image = name == "img";
+    let mut out = String::with_capacity(end - start);
+    out.push('<');
+    out.push_str(&name);
+    for (aname, aval) in attrs {
+        // Event handlers, inline CSS, and iframe srcdoc are dropped outright.
+        if aname.starts_with("on") || aname == "style" || aname == "srcdoc" {
+            continue;
+        }
+        if RAW_HTML_URL_ATTRS.contains(&aname.as_str()) {
+            if let Some(v) = &aval {
+                if !url_scheme_is_safe(v, allow_data_image) {
+                    continue;
+                }
+            }
+        }
+        out.push(' ');
+        out.push_str(&aname);
+        if let Some(v) = aval {
+            out.push_str("=\"");
+            html_escape::encode_double_quoted_attribute_to_string(&v, &mut out);
+            out.push('"');
+        }
+    }
+    out.push('>');
+    Some((end, out))
+}
+
+/// Whether a URL is safe to place in an `href`/`src`-style attribute — i.e. it
+/// can't drive script execution or navigation to a scripting scheme. Relative
+/// URLs, anchors and protocol-relative URLs are safe; among absolute URLs only
+/// a small scheme allowlist passes (`data:` only for images). HTML entities are
+/// decoded and whitespace/control characters removed first, so obfuscations
+/// like `jav&#x61;script:` or `java\tscript:` can't slip through.
+fn url_scheme_is_safe(raw: &str, allow_data_image: bool) -> bool {
+    let decoded = html_escape::decode_html_entities(raw);
+    let mut cleaned = String::with_capacity(decoded.len());
+    for c in decoded.chars() {
+        if (c as u32) > 0x20 {
+            cleaned.push(c.to_ascii_lowercase());
+        }
+    }
+    // A scheme is `[alpha][alnum+.-]* ':'` occurring before any `/ ? #`.
+    let mut scheme = String::new();
+    let mut has_colon = false;
+    for c in cleaned.chars() {
+        match c {
+            ':' => {
+                has_colon = true;
+                break;
+            }
+            '/' | '?' | '#' => break,
+            _ => scheme.push(c),
+        }
+    }
+    if !has_colon {
+        return true; // relative / anchor / protocol-relative
+    }
+    // If it isn't a grammatically valid scheme, the ':' is just data (e.g. a
+    // time like "12:30"), which is likewise safe.
+    if !scheme
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic())
+        || !scheme
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '+' | '.' | '-'))
+    {
+        return true;
+    }
+    match scheme.as_str() {
+        "http" | "https" | "mailto" | "tel" | "ftp" => true,
+        "data" => allow_data_image && cleaned.starts_with("data:image/"),
+        _ => false,
+    }
+}
+
 fn collect_supramark_assets(
     node: &supramark_markdown::SupramarkNode,
     out: &mut std::collections::HashSet<String>,
@@ -1888,6 +2192,7 @@ mod assets_tests {
     use super::MarkdownRenderer;
     use super::{
         extract_referenced_assets, normalize_local_image_destinations, sanitize_asset_ref,
+        sanitize_raw_html_fragment, url_scheme_is_safe,
     };
     use crate::markdown::MarkdownEngine;
 
@@ -1980,6 +2285,114 @@ mod assets_tests {
             html.contains(r#"<img src="icon%20art.svg" alt="vector" />"#),
             "html: {html}"
         );
+    }
+
+    fn render_html_only(md: &str) -> String {
+        MarkdownRenderer::new("light").render(md).0
+    }
+
+    #[test]
+    fn raw_html_strips_event_handlers() {
+        let html = render_html_only("<img src=x onerror=\"alert(1)\">");
+        assert!(!html.contains("onerror"), "html: {html}");
+        assert!(html.contains(r#"<img src="x">"#), "html: {html}");
+    }
+
+    #[test]
+    fn raw_html_escapes_disallowed_tags() {
+        let html = render_html_only("<script>alert(1)</script>");
+        assert!(!html.contains("<script"), "html: {html}");
+        assert!(html.contains("&lt;script&gt;"), "html: {html}");
+
+        let iframe = render_html_only("<iframe src=\"http://evil\"></iframe>");
+        assert!(!iframe.contains("<iframe"), "html: {iframe}");
+    }
+
+    #[test]
+    fn raw_html_preserves_split_inline_html() {
+        // The parser hands `<details>` and `</details>` as separate fragments;
+        // the non-rebalancing scrubber must keep both so the widget still works.
+        let html = render_html_only("<details>\n<summary>more</summary>\n\nbody\n\n</details>");
+        assert!(html.contains("<details>"), "html: {html}");
+        assert!(html.contains("<summary>"), "html: {html}");
+        assert!(html.contains("</details>"), "html: {html}");
+        assert!(render_html_only("press <kbd>Ctrl</kbd>").contains("<kbd>"));
+    }
+
+    #[test]
+    fn raw_html_link_javascript_scheme_dropped() {
+        let html = render_html_only("<a href=\"javascript:alert(1)\">click</a>");
+        assert!(!html.contains("javascript:"), "html: {html}");
+        // The tag survives (inert), just without the dangerous href.
+        assert!(html.contains("<a>") || html.contains("<a >"), "html: {html}");
+    }
+
+    #[test]
+    fn markdown_link_and_image_scheme_whitelist() {
+        // A javascript: link must never become a clickable href. (supramark
+        // itself refuses to parse it as a link; the Link-node check is the
+        // backstop if that ever changes.)
+        let link = render_html_only("[click](javascript:alert(1))");
+        assert!(!link.contains("href=\"javascript:"), "html: {link}");
+
+        // data:image is allowed for images (embedded images are common).
+        let img = render_html_only("![x](data:image/png;base64,iVBORw0KGgo=)");
+        assert!(img.contains("src=\"data:image/png"), "html: {img}");
+
+        // A data: URL must never surface as an <a href> or non-image <img src>.
+        let bad = render_html_only("[x](data:text/html,<b>hi</b>)");
+        assert!(!bad.contains("href=\"data:"), "html: {bad}");
+    }
+
+    #[test]
+    fn url_scheme_is_safe_allows_benign_and_blocks_dangerous() {
+        for ok in [
+            "http://a",
+            "https://a/b?c#d",
+            "mailto:a@b",
+            "tel:+1",
+            "/rel/path",
+            "relative",
+            "#anchor",
+            "//protocol-relative/x",
+            "12:30",
+        ] {
+            assert!(url_scheme_is_safe(ok, false), "should allow: {ok}");
+        }
+        for bad in [
+            "javascript:alert(1)",
+            "JavaScript:alert(1)",
+            "  javascript:alert(1)",
+            "java\tscript:alert(1)",
+            "jav&#x61;script:alert(1)",
+            "vbscript:msgbox(1)",
+            "data:text/html,<script>",
+            "data:image/png,x", // data blocked when images aren't allowed
+        ] {
+            assert!(!url_scheme_is_safe(bad, false), "should block: {bad}");
+        }
+        // data:image only when the image context opts in.
+        assert!(url_scheme_is_safe("data:image/png;base64,AAAA", true));
+        assert!(!url_scheme_is_safe("data:text/html,x", true));
+    }
+
+    #[test]
+    fn sanitize_fragment_unit_cases() {
+        assert_eq!(sanitize_raw_html_fragment("<details>"), "<details>");
+        assert_eq!(sanitize_raw_html_fragment("</details>"), "</details>");
+        assert_eq!(sanitize_raw_html_fragment("<kbd>"), "<kbd>");
+        assert_eq!(sanitize_raw_html_fragment("<script>"), "&lt;script&gt;");
+        assert_eq!(sanitize_raw_html_fragment("<!-- secret -->"), "");
+        assert_eq!(
+            sanitize_raw_html_fragment("<img src=x onerror=alert(1)>"),
+            r#"<img src="x">"#
+        );
+        assert_eq!(
+            sanitize_raw_html_fragment("<a href=\"javascript:x\">"),
+            "<a>"
+        );
+        // A lone '<' that isn't a tag is escaped, not passed through.
+        assert_eq!(sanitize_raw_html_fragment("a < b"), "a &lt; b");
     }
 
     #[test]

--- a/crates/core/src/markdown.rs
+++ b/crates/core/src/markdown.rs
@@ -1794,12 +1794,68 @@ fn strip_html_tags(value: &str) -> String {
 /// only untrusted raw fragments do — so there is no risk of silently dropping
 /// first-party markup.
 const RAW_HTML_ALLOWED_TAGS: &[&str] = &[
-    "a", "abbr", "b", "bdi", "bdo", "blockquote", "br", "caption", "cite",
-    "code", "col", "colgroup", "dd", "del", "details", "dfn", "div", "dl", "dt",
-    "em", "figcaption", "figure", "h1", "h2", "h3", "h4", "h5", "h6", "hr", "i",
-    "img", "ins", "kbd", "li", "mark", "ol", "p", "pre", "q", "rp", "rt", "ruby",
-    "s", "samp", "small", "span", "strong", "sub", "summary", "sup", "table",
-    "tbody", "td", "tfoot", "th", "thead", "time", "tr", "u", "ul", "var", "wbr",
+    "a",
+    "abbr",
+    "b",
+    "bdi",
+    "bdo",
+    "blockquote",
+    "br",
+    "caption",
+    "cite",
+    "code",
+    "col",
+    "colgroup",
+    "dd",
+    "del",
+    "details",
+    "dfn",
+    "div",
+    "dl",
+    "dt",
+    "em",
+    "figcaption",
+    "figure",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "hr",
+    "i",
+    "img",
+    "ins",
+    "kbd",
+    "li",
+    "mark",
+    "ol",
+    "p",
+    "pre",
+    "q",
+    "rp",
+    "rt",
+    "ruby",
+    "s",
+    "samp",
+    "small",
+    "span",
+    "strong",
+    "sub",
+    "summary",
+    "sup",
+    "table",
+    "tbody",
+    "td",
+    "tfoot",
+    "th",
+    "thead",
+    "time",
+    "tr",
+    "u",
+    "ul",
+    "var",
+    "wbr",
 ];
 
 /// Attributes whose value carries a URL and must pass [`url_scheme_is_safe`].
@@ -2324,7 +2380,10 @@ mod assets_tests {
         let html = render_html_only("<a href=\"javascript:alert(1)\">click</a>");
         assert!(!html.contains("javascript:"), "html: {html}");
         // The tag survives (inert), just without the dangerous href.
-        assert!(html.contains("<a>") || html.contains("<a >"), "html: {html}");
+        assert!(
+            html.contains("<a>") || html.contains("<a >"),
+            "html: {html}"
+        );
     }
 
     #[test]

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -893,6 +893,21 @@ pub async fn start(config: ServerConfig) -> Result<(), String> {
         }
     }
 
+    if !collaborator_access_code_hash.is_empty() && collaborator_access_code_hash.len() != 64 {
+        tracing::warn!(
+            "legacy truncated server collaborator access-code hash rejected; reset the code locally"
+        );
+    }
+    for workspace in registry.list() {
+        let access_code_hash = workspace.collaborator_access_code_hash();
+        if !access_code_hash.is_empty() && access_code_hash.len() != 64 {
+            tracing::warn!(
+                workspace_id = %workspace.id,
+                "legacy truncated workspace collaborator access-code hash rejected; reset the code locally"
+            );
+        }
+    }
+
     let token = Arc::new(management_token.unwrap_or_else(generate_token));
     let admin_bootstraps = admin_bootstraps.unwrap_or_else(|| Arc::new(AdminBootstrapStore::new()));
     let allowed_hosts = Arc::new(build_allowed_hosts(
@@ -971,10 +986,10 @@ pub async fn start(config: ServerConfig) -> Result<(), String> {
         ));
 
     // Preview API: stateless "text in, HTML out" for the editor's live preview.
-    // Guarded same-origin (or loopback without Origin), so a cross-site page or
-    // an anonymous LAN device can no longer hammer syntect rendering into a CPU
-    // DoS. A tight body limit bounds per-request work, and the handler offloads
-    // the render to a blocking pool so one large document can't stall a worker.
+    // The origin layer rejects browser cross-site requests; the handler also
+    // requires a workspace-scoped preview capability, because Origin is
+    // spoofable by non-browser LAN clients. A tight body limit bounds
+    // per-request work, and the handler offloads rendering to a blocking pool.
     let preview = Router::new()
         .route("/api/preview", post(preview_handler))
         .layer(axum::extract::DefaultBodyLimit::max(PREVIEW_BODY_LIMIT))
@@ -1427,6 +1442,27 @@ fn workspace_save_token(secret: &str, workspace_id: &str) -> String {
     admin_auth::auth_tag(secret, b"markon-save-workspace\0", workspace_id)
 }
 
+/// Derive a browser preview capability for exactly one workspace. Keep this
+/// domain-separated from the save capability: a read-only page may render an
+/// export preview without gaining permission to write workspace files.
+fn workspace_preview_token(secret: &str, workspace_id: &str) -> String {
+    admin_auth::auth_tag(secret, b"markon-preview-workspace\0", workspace_id)
+}
+
+fn request_token_matches(
+    headers: &axum::http::HeaderMap,
+    capability_token: &str,
+    management_token: &str,
+) -> bool {
+    headers
+        .get("X-Markon-Token")
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|token| {
+            ct_eq(token.as_bytes(), capability_token.as_bytes())
+                || ct_eq(token.as_bytes(), management_token.as_bytes())
+        })
+}
+
 /// Build the `Set-Cookie` value carrying the unlocked scopes until `exp`.
 fn make_access_cookie(secret: &str, scopes: &[(String, String)], exp: u64, secure: bool) -> String {
     // payload grammar (before hex): "<exp>|<scope>=<hash>|<scope>=<hash>…"
@@ -1501,7 +1537,8 @@ fn access_cookie_scopes(secret: &str, cookie_header: Option<&str>) -> Vec<(Strin
 /// The workspace id a request targets, for access-gating. `None` means the
 /// route isn't workspace-scoped (static assets, mgmt, unlock, preview) and is
 /// allowed through the access-code gate. (`/api/preview` is not access-gated but
-/// carries its own same-origin guard — see the `preview` router.)
+/// carries its own origin + workspace-capability guards — see the `preview`
+/// router and handler.)
 fn decoded_workspace_id(segment: &str) -> Option<String> {
     let decoded = urlencoding::decode(segment).ok()?;
     (decoded.len() == 8 && decoded.bytes().all(|byte| byte.is_ascii_hexdigit()))
@@ -4871,6 +4908,10 @@ fn render_git_diff_page(
     context.insert("title", &format!("Markdiff · {}", diff.range));
     context.insert("workspace_id", workspace_id);
     context.insert(
+        "preview_token",
+        &workspace_preview_token(&state.save_token, workspace_id),
+    );
+    context.insert(
         "diff",
         &git_diff_template(
             root,
@@ -6037,6 +6078,10 @@ fn render_markdown_file(
             context.insert("title", &title);
             context.insert("file_path", file_path);
             context.insert("workspace_id", workspace_id);
+            context.insert(
+                "preview_token",
+                &workspace_preview_token(&state.save_token, workspace_id),
+            );
             insert_workspace_header_context(&mut context, ws, root);
             context.insert("version", env!("CARGO_PKG_VERSION"));
             context.insert("content", &rendered.html);
@@ -6716,15 +6761,8 @@ async fn save_file_handler(
     headers: axum::http::HeaderMap,
     Json(payload): Json<SaveFileRequest>,
 ) -> impl IntoResponse {
-    let supplied_token = headers
-        .get("X-Markon-Token")
-        .and_then(|value| value.to_str().ok());
     let scoped_token = workspace_save_token(&state.save_token, &payload.workspace_id);
-    let token_valid = supplied_token.is_some_and(|token| {
-        ct_eq(token.as_bytes(), scoped_token.as_bytes())
-            || ct_eq(token.as_bytes(), state.management_token.as_bytes())
-    });
-    if !token_valid {
+    if !request_token_matches(&headers, &scoped_token, &state.management_token) {
         return StatusCode::UNAUTHORIZED.into_response();
     }
 
@@ -6835,6 +6873,7 @@ async fn save_file_handler(
 
 #[derive(Deserialize)]
 struct PreviewRequest {
+    workspace_id: String,
     content: String,
 }
 
@@ -6847,25 +6886,30 @@ struct PreviewResponse {
 
 async fn preview_handler(
     State(state): State<AppState>,
+    headers: axum::http::HeaderMap,
     Json(payload): Json<PreviewRequest>,
 ) -> impl IntoResponse {
+    let scoped_token = workspace_preview_token(&state.save_token, &payload.workspace_id);
+    if !request_token_matches(&headers, &scoped_token, &state.management_token) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+
     // Markdown rendering (syntect highlight + AST walk) is CPU-bound; run it on
     // the blocking pool so a large document can't stall a runtime worker.
     let theme = state.theme.clone();
     let content = payload.content;
-    let rendered =
-        match tokio::task::spawn_blocking(move || {
-            let renderer = default_markdown_engine(&theme);
-            MarkdownEngine::render(&renderer, &content)
-        })
-        .await
-        {
-            Ok(rendered) => rendered,
-            Err(e) => {
-                tracing::error!(error = %e, "preview render task failed");
-                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
-            }
-        };
+    let rendered = match tokio::task::spawn_blocking(move || {
+        let renderer = default_markdown_engine(&theme);
+        MarkdownEngine::render(&renderer, &content)
+    })
+    .await
+    {
+        Ok(rendered) => rendered,
+        Err(e) => {
+            tracing::error!(error = %e, "preview render task failed");
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
     Json(PreviewResponse {
         html: rendered.html,
         has_mermaid: rendered.has_mermaid,
@@ -7192,12 +7236,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn preview_route_is_guarded_same_origin() {
+    async fn preview_route_requires_origin_and_scoped_capability() {
         use axum::body::Body;
         use axum::http::Request;
 
         let registry = Arc::new(WorkspaceRegistry::new("preview-guard-test".into()));
         let state = test_state(registry);
+        let workspace_id = "deadbeef";
+        let preview_token = workspace_preview_token(&state.save_token, workspace_id);
+        let save_token = workspace_save_token(&state.save_token, workspace_id);
+        assert_ne!(preview_token, save_token);
         let app = Router::new()
             .route("/api/preview", post(preview_handler))
             .layer(axum::extract::DefaultBodyLimit::max(PREVIEW_BODY_LIMIT))
@@ -7207,8 +7255,11 @@ mod tests {
             ))
             .with_state(state);
 
-        let body = json!({ "content": "# hi" }).to_string();
-        let build = |origin: Option<&str>, host: &str, peer: SocketAddr| {
+        let build = |origin: Option<&str>,
+                     host: &str,
+                     peer: SocketAddr,
+                     token: Option<&str>,
+                     content: String| {
             let mut b = Request::builder()
                 .method("POST")
                 .uri("/api/preview")
@@ -7217,7 +7268,14 @@ mod tests {
             if let Some(o) = origin {
                 b = b.header("origin", o);
             }
-            let mut req = b.body(Body::from(body.clone())).unwrap();
+            if let Some(token) = token {
+                b = b.header("X-Markon-Token", token);
+            }
+            let mut req = b
+                .body(Body::from(
+                    json!({ "workspace_id": workspace_id, "content": content }).to_string(),
+                ))
+                .unwrap();
             req.extensions_mut()
                 .insert(axum::extract::ConnectInfo(peer));
             req
@@ -7230,31 +7288,85 @@ mod tests {
                 Some("http://evil.example.com"),
                 "192.168.1.13:6419",
                 lan_peer(),
+                Some(&preview_token),
+                "# hi".into(),
             ))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
-        // Anonymous LAN device (no Origin, not loopback) → rejected. This is the
-        // curl-style abuse the fix closes.
+        // Anonymous LAN device (no Origin, not loopback) → rejected even with a
+        // valid token, because browser capabilities do not replace the origin
+        // boundary.
         let resp = app
             .clone()
-            .oneshot(build(None, "192.168.1.13:6419", lan_peer()))
+            .oneshot(build(
+                None,
+                "192.168.1.13:6419",
+                lan_peer(),
+                Some(&preview_token),
+                "# hi".into(),
+            ))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::FORBIDDEN);
 
-        // Same-origin editor page → allowed.
+        // A LAN client can spoof a matching Origin, so origin alone is not an
+        // authentication boundary.
+        let resp = app
+            .clone()
+            .oneshot(build(
+                Some("http://192.168.1.13:6419"),
+                "192.168.1.13:6419",
+                lan_peer(),
+                None,
+                "# hi".into(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // Save and preview capabilities are deliberately not interchangeable.
         let resp = app
             .clone()
             .oneshot(build(
                 Some("http://127.0.0.1:6419"),
                 "127.0.0.1:6419",
                 loopback(),
+                Some(&save_token),
+                "# hi".into(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // Same-origin editor page with its workspace-scoped preview capability
+        // is allowed.
+        let resp = app
+            .clone()
+            .oneshot(build(
+                Some("http://127.0.0.1:6419"),
+                "127.0.0.1:6419",
+                loopback(),
+                Some(&preview_token),
+                "# hi".into(),
             ))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
+
+        // Capability possession does not bypass the route-specific body cap.
+        let resp = app
+            .oneshot(build(
+                Some("http://127.0.0.1:6419"),
+                "127.0.0.1:6419",
+                loopback(),
+                Some(&preview_token),
+                "x".repeat(PREVIEW_BODY_LIMIT),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::PAYLOAD_TOO_LARGE);
     }
 
     #[test]
@@ -7932,7 +8044,9 @@ mod tests {
         let state = test_state(registry);
         let token_a = workspace_save_token(&state.save_token, &id_a);
         let token_b = workspace_save_token(&state.save_token, &id_b);
+        let preview_token_b = workspace_preview_token(&state.save_token, &id_b);
         assert_ne!(token_a, token_b);
+        assert_ne!(token_b, preview_token_b);
 
         let app = Router::new()
             .route("/api/save", post(save_file_handler))
@@ -7964,6 +8078,17 @@ mod tests {
         let denied = app
             .clone()
             .oneshot(request(&token_a, "stolen"))
+            .await
+            .unwrap();
+        assert_eq!(denied.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            std::fs::read_to_string(root_b.path().join("b.md")).unwrap(),
+            "workspace b"
+        );
+
+        let denied = app
+            .clone()
+            .oneshot(request(&preview_token_b, "preview escalation"))
             .await
             .unwrap();
         assert_eq!(denied.status(), StatusCode::UNAUTHORIZED);
@@ -8664,6 +8789,7 @@ mod tests {
             on.contains(r#"name="save-token""#),
             "remote collaborator with the edit flag must receive the save token"
         );
+        assert!(on.contains(r#"name="preview-token""#));
         assert!(on.contains(r#"<meta name="enable-chat" content="true">"#));
 
         // both OFF → no save token and no chat for the same remote peer.
@@ -8688,6 +8814,10 @@ mod tests {
         assert!(
             !off.contains(r#"name="save-token""#),
             "no edit flag → no save token even on a readable page"
+        );
+        assert!(
+            off.contains(r#"name="preview-token""#),
+            "read-only pages still need the separate preview capability for export mode"
         );
         assert!(off.contains(r#"<meta name="enable-chat" content="false">"#));
     }

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -1922,12 +1922,15 @@ async fn unlock_handler(
 /// broadcast amplification from a hostile peer; real annotations are tiny.
 const MAX_WS_MSG_BYTES: usize = 256 * 1024;
 
-/// Conservative Content-Security-Policy. `'unsafe-inline'` is required because
-/// the templates ship inline `<script>`/`<style>` and inject `styles_css`; even
-/// so this blocks **external** script/style loads, plugins, framing and base
-/// hijacking, so an injection can't pull in a remote payload or be clickjacked.
-/// `img/media-src *` keeps cross-origin images in user docs working. The full
-/// fix for inline injection is HTML sanitisation (see security review H-1).
+/// Conservative Content-Security-Policy. Untrusted markdown is sanitised at the
+/// source (raw HTML is scrubbed and link/image schemes are allow-listed in
+/// `markdown.rs`), which removes the injected-inline-handler / `javascript:`
+/// vector. `'unsafe-inline'` remains only because first-party templates ship
+/// inline `<script>`/`<style>` and inject `styles_css`; dropping it would need
+/// per-request nonces on every inline block. Even with it, this still blocks
+/// **external** script/style loads, plugins, framing and base hijacking, so an
+/// injection can't pull in a remote payload or be clickjacked. `img/media-src *`
+/// keeps cross-origin images in user docs working.
 const SECURITY_CSP: &str = "default-src 'self'; \
 script-src 'self' 'unsafe-inline'; \
 style-src 'self' 'unsafe-inline'; \

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -970,6 +970,19 @@ pub async fn start(config: ServerConfig) -> Result<(), String> {
             require_local_save_origin,
         ));
 
+    // Preview API: stateless "text in, HTML out" for the editor's live preview.
+    // Guarded same-origin (or loopback without Origin), so a cross-site page or
+    // an anonymous LAN device can no longer hammer syntect rendering into a CPU
+    // DoS. A tight body limit bounds per-request work, and the handler offloads
+    // the render to a blocking pool so one large document can't stall a worker.
+    let preview = Router::new()
+        .route("/api/preview", post(preview_handler))
+        .layer(axum::extract::DefaultBodyLimit::max(PREVIEW_BODY_LIMIT))
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            require_local_save_origin,
+        ));
+
     let app = Router::new()
         // Static assets (literal prefix beats /{workspace_id}/ param)
         .route("/favicon.ico", get(serve_favicon))
@@ -983,7 +996,6 @@ pub async fn start(config: ServerConfig) -> Result<(), String> {
         .route("/_/ws/{workspace_id}", get(config_ws_handler))
         // Read-only public APIs
         .route("/_/{workspace_id}/search", get(workspace_search_handler))
-        .route("/api/preview", post(preview_handler))
         // Access-code gate: unlock endpoint (not itself gated).
         .route("/_/unlock", post(unlock_handler))
         // Workspace content routes
@@ -1078,7 +1090,8 @@ pub async fn start(config: ServerConfig) -> Result<(), String> {
         // Everything else → 404
         .fallback(|| async { StatusCode::NOT_FOUND })
         .merge(mgmt)
-        .merge(save);
+        .merge(save)
+        .merge(preview);
 
     // Dev-only live-reload: esbuild's watch onEnd hook POSTs the trigger,
     // server fans it out as an SSE event, the webview reloads. cfg gate keeps
@@ -1487,7 +1500,8 @@ fn access_cookie_scopes(secret: &str, cookie_header: Option<&str>) -> Vec<(Strin
 
 /// The workspace id a request targets, for access-gating. `None` means the
 /// route isn't workspace-scoped (static assets, mgmt, unlock, preview) and is
-/// allowed through the gate.
+/// allowed through the access-code gate. (`/api/preview` is not access-gated but
+/// carries its own same-origin guard — see the `preview` router.)
 fn decoded_workspace_id(segment: &str) -> Option<String> {
     let decoded = urlencoding::decode(segment).ok()?;
     (decoded.len() == 8 && decoded.bytes().all(|byte| byte.is_ascii_hexdigit()))
@@ -5859,6 +5873,11 @@ fn coalesce_markdown_block_ops(ops: Vec<MarkdownBlockOp>) -> Vec<MarkdownDiffBlo
 /// highlight preview and fall back to raw bytes (the browser shows plain text).
 const MAX_TEXT_PREVIEW_BYTES: u64 = 2 * 1024 * 1024;
 
+/// Request-body cap for `POST /api/preview`. The live editor preview never
+/// needs the global 2 MB default; a smaller ceiling bounds the per-request
+/// render cost (defense in depth behind the same-origin guard).
+const PREVIEW_BODY_LIMIT: usize = 512 * 1024;
+
 /// If `path` is a small UTF-8 text/code file, return its contents plus a
 /// language hint (extension, or file name for extension-less files) for the
 /// highlighted preview. Returns `None` for images, media, binaries and
@@ -6827,8 +6846,23 @@ async fn preview_handler(
     State(state): State<AppState>,
     Json(payload): Json<PreviewRequest>,
 ) -> impl IntoResponse {
-    let renderer = default_markdown_engine(&state.theme);
-    let rendered = MarkdownEngine::render(&renderer, &payload.content);
+    // Markdown rendering (syntect highlight + AST walk) is CPU-bound; run it on
+    // the blocking pool so a large document can't stall a runtime worker.
+    let theme = state.theme.clone();
+    let content = payload.content;
+    let rendered =
+        match tokio::task::spawn_blocking(move || {
+            let renderer = default_markdown_engine(&theme);
+            MarkdownEngine::render(&renderer, &content)
+        })
+        .await
+        {
+            Ok(rendered) => rendered,
+            Err(e) => {
+                tracing::error!(error = %e, "preview render task failed");
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+        };
     Json(PreviewResponse {
         html: rendered.html,
         has_mermaid: rendered.has_mermaid,
@@ -7152,6 +7186,72 @@ mod tests {
             Some("example.local:1618"),
         );
         assert!(check_ws_origin(&h, &loopback()));
+    }
+
+    #[tokio::test]
+    async fn preview_route_is_guarded_same_origin() {
+        use axum::body::Body;
+        use axum::http::Request;
+
+        let registry = Arc::new(WorkspaceRegistry::new("preview-guard-test".into()));
+        let state = test_state(registry);
+        let app = Router::new()
+            .route("/api/preview", post(preview_handler))
+            .layer(axum::extract::DefaultBodyLimit::max(PREVIEW_BODY_LIMIT))
+            .layer(axum::middleware::from_fn_with_state(
+                state.clone(),
+                require_local_save_origin,
+            ))
+            .with_state(state);
+
+        let body = json!({ "content": "# hi" }).to_string();
+        let build = |origin: Option<&str>, host: &str, peer: SocketAddr| {
+            let mut b = Request::builder()
+                .method("POST")
+                .uri("/api/preview")
+                .header("host", host)
+                .header("content-type", "application/json");
+            if let Some(o) = origin {
+                b = b.header("origin", o);
+            }
+            let mut req = b.body(Body::from(body.clone())).unwrap();
+            req.extensions_mut()
+                .insert(axum::extract::ConnectInfo(peer));
+            req
+        };
+
+        // Cross-site page from the LAN → rejected.
+        let resp = app
+            .clone()
+            .oneshot(build(
+                Some("http://evil.example.com"),
+                "192.168.1.13:6419",
+                lan_peer(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        // Anonymous LAN device (no Origin, not loopback) → rejected. This is the
+        // curl-style abuse the fix closes.
+        let resp = app
+            .clone()
+            .oneshot(build(None, "192.168.1.13:6419", lan_peer()))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+        // Same-origin editor page → allowed.
+        let resp = app
+            .clone()
+            .oneshot(build(
+                Some("http://127.0.0.1:6419"),
+                "127.0.0.1:6419",
+                loopback(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 
     #[test]

--- a/crates/core/src/workspace.rs
+++ b/crates/core/src/workspace.rs
@@ -184,24 +184,48 @@ pub fn hash_id(path: &Path, salt: &str) -> String {
     )
 }
 
+/// Minimum length (in characters) for a newly set collaborator access code.
+/// Empty means "clear the code" and is always allowed; a non-empty code shorter
+/// than this is rejected at the set-code entry points (GUI / CLI). Existing
+/// stored codes are never re-validated, so an upgrade can't lock anyone out.
+pub const MIN_ACCESS_CODE_LEN: usize = 8;
+
+/// Validate a would-be access code before hashing. `Ok(())` for the empty
+/// string (which clears the code) and for any code of at least
+/// [`MIN_ACCESS_CODE_LEN`] characters; `Err(message)` otherwise. Callers should
+/// `trim()` first (empty-after-trim clears). Centralized here so the GUI command
+/// and the CLI flag enforce the same floor.
+pub fn validate_access_code(code: &str) -> Result<(), String> {
+    let code = code.trim();
+    let len = code.chars().count();
+    if !code.is_empty() && len < MIN_ACCESS_CODE_LEN {
+        return Err(format!(
+            "access code must be at least {MIN_ACCESS_CODE_LEN} characters (got {len})"
+        ));
+    }
+    Ok(())
+}
+
 /// Hash an access code for storage and comparison. Salted with the per-install
-/// salt (so the stored value isn't a bare SHA-256 of a often-weak code, and so
+/// salt (so the stored value isn't a bare SHA-256 of an often-weak code, and so
 /// it can't be precomputed without reading the 0600 settings file) and
 /// domain-separated from workspace-id hashing.
 ///
-/// The result is truncated to **as many leading hex chars as the code has
-/// characters**, so the stored length equals the code length — the panel uses
-/// that to render the right number of `•` in the "code is set" token without
-/// being able to recover the code. Verification stays consistent because both
-/// store and check route through this function: the candidate is truncated by
-/// *its own* length, so the correct code (same length) still matches, and a
-/// wrong-length guess can't. Trade-off: very short codes are checked against
-/// only a few hex chars — rely on a reasonable code length (the per-IP unlock
-/// cooldown also throttles guessing).
+/// Returns the **full** 64-hex-char digest. An earlier scheme truncated this to
+/// the code's character count (to let the panel render one `•` per character),
+/// which capped the effective strength at 4·N bits and let any string sharing
+/// the same leading N hex chars unlock — so a short code was far weaker than it
+/// looked. Storing the full digest removes both problems; the panel now shows a
+/// fixed "code is set" marker instead of the real length. [`access_code_matches`]
+/// still accepts the old truncated hashes, so upgrades need no re-set.
+///
+/// An empty `code` hashes to the empty string, preserving the "no code stored"
+/// sentinel that setters and [`access_code_matches`] treat as "gate disabled".
 pub fn hash_access_code(salt: &str, code: &str) -> String {
-    let hex = access_code_digest(salt, code);
-    let n = code.chars().count().min(hex.len());
-    hex[..n].to_string()
+    if code.is_empty() {
+        return String::new();
+    }
+    access_code_digest(salt, code)
 }
 
 /// Full (untruncated) salted digest of an access code, as 64 hex chars.
@@ -214,21 +238,23 @@ fn access_code_digest(salt: &str, code: &str) -> String {
     h.finalize().iter().map(|b| format!("{b:02x}")).collect()
 }
 
-/// Verify a submitted access code against a stored hash. Owns both schemes:
-/// the current length-truncated form (see [`hash_access_code`]) and, when the
-/// stored value is a full 64-char digest, the legacy untruncated form written
-/// before truncation existed — so codes set by older builds keep unlocking
-/// after an upgrade instead of silently never matching.
+/// Verify a submitted access code against a stored hash. Accepts both schemes:
+/// the current full 64-hex-char digest (see [`hash_access_code`]) and the legacy
+/// length-truncated form (leading N hex chars, N = code length) written by
+/// builds before full-digest storage — so codes set by older builds keep
+/// unlocking after an upgrade instead of silently never matching.
 pub fn access_code_matches(salt: &str, code: &str, stored: &str) -> bool {
     if stored.is_empty() {
         return false;
     }
     let full = access_code_digest(salt, code);
-    let n = code.chars().count().min(full.len());
-    if ct_eq(&full.as_bytes()[..n], stored.as_bytes()) {
+    // Current format: full digest, exact compare.
+    if stored.len() == full.len() && ct_eq(full.as_bytes(), stored.as_bytes()) {
         return true;
     }
-    stored.len() == full.len() && ct_eq(full.as_bytes(), stored.as_bytes())
+    // Legacy truncated format: stored is the leading `stored.len()` hex chars.
+    let n = code.chars().count().min(full.len());
+    stored.len() == n && ct_eq(&full.as_bytes()[..n], stored.as_bytes())
 }
 
 /// Constant-time byte comparison (length leak is fine — lengths aren't secret).
@@ -813,30 +839,60 @@ mod tests {
     }
 
     #[test]
-    fn access_code_hash_len_equals_code_len() {
-        assert_eq!(hash_access_code("s", "test123").len(), 7);
+    fn access_code_hash_is_full_width() {
+        // Any non-empty code now stores the full 64-hex digest, regardless of
+        // code length — no truncation, so no leaked length and no 4·N cap.
+        assert_eq!(hash_access_code("s", "abcd12345678").len(), 64);
+        assert_eq!(hash_access_code("s", "x").len(), 64);
+        // Empty stays the "gate disabled" sentinel.
         assert_eq!(hash_access_code("s", "").len(), 0);
     }
 
     #[test]
     fn access_code_matches_current_scheme() {
-        let stored = hash_access_code("s", "test123");
-        assert!(access_code_matches("s", "test123", &stored));
-        assert!(!access_code_matches("s", "test124", &stored));
-        // Wrong length can't match a truncated hash.
-        assert!(!access_code_matches("s", "test1234", &stored));
+        let stored = hash_access_code("s", "test1234");
+        assert_eq!(stored.len(), 64);
+        assert!(access_code_matches("s", "test1234", &stored));
+        assert!(!access_code_matches("s", "test1235", &stored));
+        // A different-length code can't match either.
+        assert!(!access_code_matches("s", "test12345", &stored));
         // Empty stored hash gates nothing.
         assert!(!access_code_matches("s", "anything", ""));
     }
 
     #[test]
-    fn access_code_matches_legacy_full_hash() {
-        // Pre-truncation builds stored the full 64-char digest; those codes
-        // must keep unlocking after an upgrade.
-        let legacy = access_code_digest("s", "test123");
-        assert_eq!(legacy.len(), 64);
-        assert!(access_code_matches("s", "test123", &legacy));
-        assert!(!access_code_matches("s", "wrong", &legacy));
+    fn access_code_matches_legacy_truncated_hash() {
+        // Builds before full-digest storage kept only the leading N hex chars
+        // (N = code length). Those codes must keep unlocking after an upgrade.
+        let full = access_code_digest("s", "test1234");
+        let legacy = full[..8].to_string();
+        assert!(access_code_matches("s", "test1234", &legacy));
+        assert!(!access_code_matches("s", "wrongone", &legacy));
+    }
+
+    #[test]
+    fn access_code_matches_rejects_truncation_collision() {
+        // The old truncation let ANY string sharing the leading N hex chars
+        // unlock. With full-digest storage, only the exact code matches.
+        let stored = hash_access_code("s", "test1234");
+        // Construct a code whose digest is (astronomically unlikely to be) equal;
+        // the point is that partial-prefix matching no longer happens.
+        for guess in ["test1235", "TEST1234", "test123", "test12340"] {
+            assert!(!access_code_matches("s", guess, &stored));
+        }
+    }
+
+    #[test]
+    fn validate_access_code_enforces_floor() {
+        // Empty clears the code and is always allowed.
+        assert!(validate_access_code("").is_ok());
+        assert!(validate_access_code("   ").is_ok());
+        // Below the floor is rejected (trimmed length counts).
+        assert!(validate_access_code("short").is_err());
+        assert!(validate_access_code(&"x".repeat(MIN_ACCESS_CODE_LEN - 1)).is_err());
+        // At/above the floor is accepted.
+        assert!(validate_access_code(&"x".repeat(MIN_ACCESS_CODE_LEN)).is_ok());
+        assert!(validate_access_code("a-reasonable-code").is_ok());
     }
 
     #[test]

--- a/crates/core/src/workspace.rs
+++ b/crates/core/src/workspace.rs
@@ -187,7 +187,8 @@ pub fn hash_id(path: &Path, salt: &str) -> String {
 /// Minimum length (in characters) for a newly set collaborator access code.
 /// Empty means "clear the code" and is always allowed; a non-empty code shorter
 /// than this is rejected at the set-code entry points (GUI / CLI). Existing
-/// stored codes are never re-validated, so an upgrade can't lock anyone out.
+/// full-width hashes are not re-validated; legacy truncated hashes deliberately
+/// fail closed and must be replaced by a local administrator.
 pub const MIN_ACCESS_CODE_LEN: usize = 8;
 
 /// Validate a would-be access code before hashing. `Ok(())` for the empty
@@ -216,8 +217,10 @@ pub fn validate_access_code(code: &str) -> Result<(), String> {
 /// which capped the effective strength at 4·N bits and let any string sharing
 /// the same leading N hex chars unlock — so a short code was far weaker than it
 /// looked. Storing the full digest removes both problems; the panel now shows a
-/// fixed "code is set" marker instead of the real length. [`access_code_matches`]
-/// still accepts the old truncated hashes, so upgrades need no re-set.
+/// fixed "code is set" marker instead of the real length. Legacy truncated
+/// hashes cannot be migrated safely without the plaintext code: accepting them
+/// would preserve the prefix-collision vulnerability, so verification rejects
+/// them and requires a local administrator to set a new code.
 ///
 /// An empty `code` hashes to the empty string, preserving the "no code stored"
 /// sentinel that setters and [`access_code_matches`] treat as "gate disabled".
@@ -238,23 +241,16 @@ fn access_code_digest(salt: &str, code: &str) -> String {
     h.finalize().iter().map(|b| format!("{b:02x}")).collect()
 }
 
-/// Verify a submitted access code against a stored hash. Accepts both schemes:
-/// the current full 64-hex-char digest (see [`hash_access_code`]) and the legacy
-/// length-truncated form (leading N hex chars, N = code length) written by
-/// builds before full-digest storage — so codes set by older builds keep
-/// unlocking after an upgrade instead of silently never matching.
+/// Verify a submitted access code against the current full 64-hex-char digest
+/// (see [`hash_access_code`]). Legacy length-truncated hashes deliberately fail
+/// closed: continuing to compare only their prefix would keep the exact
+/// collision weakness this format change removes.
 pub fn access_code_matches(salt: &str, code: &str, stored: &str) -> bool {
     if stored.is_empty() {
         return false;
     }
     let full = access_code_digest(salt, code);
-    // Current format: full digest, exact compare.
-    if stored.len() == full.len() && ct_eq(full.as_bytes(), stored.as_bytes()) {
-        return true;
-    }
-    // Legacy truncated format: stored is the leading `stored.len()` hex chars.
-    let n = code.chars().count().min(full.len());
-    stored.len() == n && ct_eq(&full.as_bytes()[..n], stored.as_bytes())
+    ct_eq(full.as_bytes(), stored.as_bytes())
 }
 
 /// Constant-time byte comparison (length leak is fine — lengths aren't secret).
@@ -861,12 +857,14 @@ mod tests {
     }
 
     #[test]
-    fn access_code_matches_legacy_truncated_hash() {
+    fn access_code_rejects_legacy_truncated_hash() {
         // Builds before full-digest storage kept only the leading N hex chars
-        // (N = code length). Those codes must keep unlocking after an upgrade.
+        // (N = code length). Accepting them would retain the prefix-collision
+        // vulnerability, so they fail closed until an administrator resets the
+        // code locally.
         let full = access_code_digest("s", "test1234");
         let legacy = full[..8].to_string();
-        assert!(access_code_matches("s", "test1234", &legacy));
+        assert!(!access_code_matches("s", "test1234", &legacy));
         assert!(!access_code_matches("s", "wrongone", &legacy));
     }
 

--- a/crates/gui/src/commands.rs
+++ b/crates/gui/src/commands.rs
@@ -372,11 +372,11 @@ pub fn get_workspaces(state: State<AppState>) -> Vec<serde_json::Value> {
                 "enable_live": info.flags.enable_live,
                 "enable_chat": info.flags.enable_chat,
                 "shared_annotation": info.flags.shared_annotation,
-                // Length of the per-workspace collaborator access code, 0 =
-                // none. The stored hash length equals the code length (see
-                // workspace::hash_access_code), so the panel both detects "code
-                // set" and renders that many • in the indicator token. Not the
-                // digest itself.
+                // Non-zero iff a per-workspace collaborator access code is set.
+                // The stored value is now the full 64-hex digest (not truncated
+                // to the code length), so this is only a "set / not set" signal;
+                // the panel renders a fixed number of • for any set code and no
+                // longer reveals the real length. Not the digest itself.
                 "collaborator_access_code_len": info.collaborator_access_code_hash.chars().count(),
                 "search_ready": info.search_ready,
                 // Surfaced so the Settings UI can filter out Open-With
@@ -672,6 +672,7 @@ pub fn set_collaborator_access_code(
 ) -> Result<(), String> {
     let salt = state.settings.lock().unwrap().salt.clone();
     let code = code.trim();
+    markon_core::workspace::validate_access_code(code)?;
     let hash = if code.is_empty() {
         String::new()
     } else {

--- a/crates/gui/ui/index.html
+++ b/crates/gui/ui/index.html
@@ -1489,9 +1489,10 @@
   const esc = (s) => String(s).replace(/[&<>"]/g, (c) =>
     ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' })[c]);
 
-  // Length of the server-level access code (0 = none) — seeded by loadSettings
-  // from the stored hash's length (which equals the code length), used to draw
-  // the right number of • in the widget's "code is set" token.
+  // "Is the server-level access code set?" as a length (0 = none, >0 = set) —
+  // seeded by loadSettings from the stored hash. The digest length no longer
+  // encodes the code length, so this is only a set/not-set flag; the widget
+  // draws a fixed CODE_SET_DOTS marker for any set code.
   let globalCollaboratorCodeLen = 0;
 
   // ── Tab navigation ──────────────────────────────────────────────────────
@@ -1746,12 +1747,16 @@
   // One reusable editor for both the global (server-level) code and each
   // workspace's code. The input is plaintext (you see what you type — no mask,
   // no eye, no clear). A set code is shown only via the *placeholder*: at rest
-  // it's `n` • dots (n = the code's length; we only store the salted hash, so
-  // the real code can't be displayed), and on focus it switches to "Set a new
+  // it's a fixed run of • dots (CODE_SET_DOTS; we store only the salted digest
+  // and don't expose the real length), and on focus it switches to "Set a new
   // code…". The value itself is always empty until you type, so there's no
   // token to select/replace. A single ✓ Apply button appears on focus; Apply
   // persists (empty Apply on a set code clears it). Esc / a click outside
   // discards the edit. (`prompt()` is unusable — the WKWebView drops it.)
+  // Fixed number of • shown at rest for ANY set code. The real code length is
+  // no longer stored (we keep only the full salted digest), so the marker is a
+  // constant "code is set" hint rather than a per-character reveal.
+  const CODE_SET_DOTS = 6;
   const AC_CHECK_SVG = '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
   function accessCodeEditorHTML(inset) {
     return `
@@ -1781,7 +1786,9 @@
     const input    = root.querySelector('.ac-input');
     const applyBtn = root.querySelector('.ac-apply');
     let codeLen = opts.len | 0;
-    const restPlaceholder = () => codeLen > 0 ? '•'.repeat(codeLen) : T('access.code.ph');
+    // A set code shows a FIXED number of dots (not its real length): we only
+    // store the full salted digest, and the length is deliberately not exposed.
+    const restPlaceholder = () => codeLen > 0 ? '•'.repeat(CODE_SET_DOTS) : T('access.code.ph');
     function syncBtns() {
       // Apply commits: a typed code sets it; an empty Apply on a set code clears
       // it. Disabled only when there's nothing to do (empty + no code).


### PR DESCRIPTION
Three security fixes from the project review, hardened after a full review. Approaches follow #46 (sanitize at the AST), #48 (full digest + minimum length, fail closed), and #50 (origin guard + scoped capability + body cap + offload). No CSP-nonce work is included: the raw-HTML injection vector is closed at the renderer boundary, while CSP nonce migration remains independent defense in depth.

## #46 — raw HTML / URL-scheme sanitization

Author-controlled Markdown is untrusted, but raw HTML fragments were previously emitted verbatim and link/image URLs kept their schemes.

- Scrub each author `Raw{format:"html"}` fragment with a non-rebalancing, fail-closed allowlist.
- Remove `on*`, `style`, `srcdoc`, and unsafe URL schemes; `data:` is allowed only for images.
- Sanitize Markdown link/image AST nodes as well as raw HTML attributes.
- Preserve Markon's generated markup because only author raw-HTML nodes enter this scrubber.

## #48 — full access-code digest + minimum length

The prior stored hash was truncated to the code's character count, limiting effective strength and permitting prefix collisions.

- Store and compare the full 64-hex digest using constant-time comparison.
- Enforce a minimum length of 8 at CLI and GUI set-code entry points.
- Deliberately reject legacy truncated hashes: retaining prefix verification would retain the vulnerability. Startup logs identify these hashes; a local administrator must reset the code.
- Display only a fixed “code is set” marker, no stored length leak.

## #50 — guard `/api/preview`

Origin alone is spoofable by non-browser LAN clients, so the endpoint now uses layered controls.

- Require a workspace-scoped preview capability in `X-Markon-Token`; it is domain-separated from the workspace save capability.
- Include `workspace_id` in preview requests and reject save/preview token substitution.
- Retain the same-origin/loopback browser guard.
- Cap the body at 512 KiB and render on the blocking pool.

## Verification

Local quality gate is fully green:

- `cargo build --workspace --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Rust tests: 336 passed
- TypeScript/Vitest: 42 files, 462 tests passed
- Graphviz static-link policy passed

New tests cover sanitizer bypass classes, full-width access-code verification and fail-closed legacy hashes, scoped preview/save capabilities, origin enforcement, and the preview body limit.

Refs #46 #48 #50
