### PR TITLE
feat: GUI attaches to a running server as a controller (#55)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use dialoguer::Select;
+use markon_core::control::RunningServer;
 use markon_core::net::{available_bind_hosts, BindHostKind};
 use markon_core::server::{self, ServerConfig, WorkspaceInit};
 use markon_core::settings::AppSettings;
@@ -184,16 +185,6 @@ struct WorkspaceAccessSummary {
     featured_url: String,
     public_url: Option<String>,
     qr_url: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct WorkspaceListEntry {
-    id: String,
-    path: String,
-    #[serde(flatten)]
-    flags: WorkspaceFlags,
-    #[serde(default)]
-    search_ready: bool,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -485,37 +476,15 @@ fn print_workspace_access_summary(summary: &WorkspaceAccessSummary) {
     }
 }
 
-/// Fetch the running server's workspace list (GET /api/workspaces).
-async fn fetch_workspaces(
-    client: &reqwest::Client,
-    port: u16,
-    token: &str,
-) -> Result<Vec<WorkspaceListEntry>, Box<dyn std::error::Error>> {
-    Ok(client
-        .get(format!("http://127.0.0.1:{port}/api/workspaces"))
-        .header("X-Markon-Token", token)
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?)
-}
-
 async fn list_workspaces(
     bind_host: &str,
     advertised_host: &str,
-    port: u16,
-    token: &str,
+    server: &RunningServer,
     format: WorkspaceListFormat,
     entry: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Must use the async reqwest client. reqwest::blocking::Client::new()
-    // spins up its own internal tokio runtime; constructing it from inside
-    // an outer tokio runtime (we run under #[tokio::main]) panics on drop
-    // with "Cannot drop a runtime in a context where blocking is not
-    // allowed". Same applies to every other CLI -> server HTTP call below.
-    let client = reqwest::Client::new();
-    let workspaces = fetch_workspaces(&client, port, token).await?;
+    let port = server.port();
+    let workspaces = server.list_workspaces().await?;
 
     if workspaces.is_empty() {
         println!("No active workspaces.");
@@ -629,12 +598,10 @@ async fn list_workspaces(
 }
 
 async fn detach_workspace(
-    port: u16,
-    token: &str,
+    server: &RunningServer,
     target: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let client = reqwest::Client::new();
-    let workspaces = fetch_workspaces(&client, port, token).await?;
+    let workspaces = server.list_workspaces().await?;
 
     let id = if let Ok(idx) = target.parse::<usize>() {
         if idx == 0 || idx > workspaces.len() {
@@ -645,12 +612,7 @@ async fn detach_workspace(
         target
     };
 
-    client
-        .delete(format!("http://127.0.0.1:{port}/api/workspace/{id}"))
-        .header("X-Markon-Token", token)
-        .send()
-        .await?
-        .error_for_status()?;
+    server.remove_workspace(id).await?;
 
     println!("Workspace '{id}' detached.");
     Ok(())
@@ -660,8 +622,7 @@ async fn detach_workspace(
 /// Fetches the current flags, flips the requested one, and PUTs the full set
 /// back (the mgmt endpoint replaces flags wholesale).
 async fn set_workspace_feature(
-    port: u16,
-    token: &str,
+    server: &RunningServer,
     target: &str,
     feature: &str,
     value: &str,
@@ -671,8 +632,7 @@ async fn set_workspace_feature(
         "off" | "false" | "0" | "no" | "disable" | "disabled" => false,
         other => return Err(format!("Invalid value '{other}' — use on or off").into()),
     };
-    let client = reqwest::Client::new();
-    let workspaces = fetch_workspaces(&client, port, token).await?;
+    let workspaces = server.list_workspaces().await?;
     let entry = if let Ok(idx) = target.parse::<usize>() {
         if idx == 0 || idx > workspaces.len() {
             return Err(format!("Index {idx} out of range (1-{})", workspaces.len()).into());
@@ -700,25 +660,13 @@ async fn set_workspace_feature(
             .into())
         }
     }
-    client
-        .put(format!("http://127.0.0.1:{port}/api/workspace/{id}"))
-        .header("X-Markon-Token", token)
-        .json(&flags)
-        .send()
-        .await?
-        .error_for_status()?;
+    server.update_flags(&id, flags).await?;
     println!("{id}: {feature} = {}", if on { "on" } else { "off" });
     Ok(())
 }
 
-async fn shutdown_server(port: u16, token: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let client = reqwest::Client::new();
-    client
-        .post(format!("http://127.0.0.1:{port}/api/shutdown"))
-        .header("X-Markon-Token", token)
-        .send()
-        .await?
-        .error_for_status()?;
+async fn shutdown_server(server: &RunningServer) -> Result<(), Box<dyn std::error::Error>> {
+    server.shutdown().await?;
 
     println!("Markon server is shutting down.");
     Ok(())
@@ -755,12 +703,12 @@ async fn request_admin_bootstrap(
 }
 
 async fn admin_browser_command(
-    port: u16,
-    token: &str,
+    server: &RunningServer,
     command: AdminCommands,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let client = reqwest::Client::new();
-    let workspaces = fetch_workspaces(&client, port, token).await?;
+    let port = server.port();
+    let token = server.token();
+    let workspaces = server.list_workspaces().await?;
     let redirect = workspaces
         .first()
         .map(|workspace| server::workspace_url_path(&workspace.id, None))
@@ -789,69 +737,6 @@ async fn admin_browser_command(
         }
     }
     Ok(())
-}
-
-async fn add_or_update_workspace(
-    port: u16,
-    token: &str,
-    ws_path: &str,
-    flags: WorkspaceFlags,
-    collaborator_access_code_hash: Option<&str>,
-) -> Result<String, Box<dyn std::error::Error>> {
-    let client = reqwest::Client::new();
-
-    // Mirrors the server's AddWorkspaceRequest so a new WorkspaceFlags field is
-    // carried automatically. The collaborator hash is already salted on the CLI
-    // side and is optional: omitted means "inherit global/no change".
-    #[derive(Serialize)]
-    struct AddWorkspaceBody<'a> {
-        path: &'a str,
-        #[serde(flatten)]
-        flags: WorkspaceFlags,
-        #[serde(default, skip_serializing_if = "str::is_empty")]
-        collaborator_access_code_hash: &'a str,
-    }
-
-    #[derive(Serialize)]
-    struct WorkspaceAccessBody<'a> {
-        #[serde(skip_serializing_if = "Option::is_none")]
-        collaborator_access_code_hash: Option<&'a str>,
-    }
-
-    // Check if this path is already a registered workspace.
-    let workspaces = fetch_workspaces(&client, port, token).await?;
-
-    if let Some(existing) = workspaces.iter().find(|w| w.path == ws_path) {
-        let id = &existing.id;
-        if collaborator_access_code_hash.is_some() {
-            client
-                .put(format!("http://127.0.0.1:{port}/api/workspace/{id}/access"))
-                .header("X-Markon-Token", token)
-                .json(&WorkspaceAccessBody {
-                    collaborator_access_code_hash,
-                })
-                .send()
-                .await?
-                .error_for_status()?;
-        }
-        return Ok(id.clone());
-    }
-
-    let resp: serde_json::Value = client
-        .post(format!("http://127.0.0.1:{port}/api/workspace"))
-        .header("X-Markon-Token", token)
-        .json(&AddWorkspaceBody {
-            path: ws_path,
-            flags,
-            collaborator_access_code_hash: collaborator_access_code_hash.unwrap_or_default(),
-        })
-        .send()
-        .await?
-        .error_for_status()?
-        .json()
-        .await?;
-    let id = resp["id"].as_str().ok_or("no id in response")?;
-    Ok(id.to_string())
 }
 
 fn init_tracing() {
@@ -899,8 +784,9 @@ async fn main() {
             }
         };
 
+        let server = RunningServer::new(port, token);
         let res = match cmd {
-            Commands::Admin { command } => admin_browser_command(port, &token, command).await,
+            Commands::Admin { command } => admin_browser_command(&server, command).await,
             Commands::Ls { format } => {
                 // Reproduce the daemon's reachable URLs: bind host from the
                 // lock, advertised preference from the shared global config.
@@ -913,20 +799,19 @@ async fn main() {
                 list_workspaces(
                     &bind_host,
                     &advertised_host,
-                    port,
-                    &token,
+                    &server,
                     format,
                     cli_entry.as_deref(),
                 )
                 .await
             }
-            Commands::Detach { target } => detach_workspace(port, &token, &target).await,
+            Commands::Detach { target } => detach_workspace(&server, &target).await,
             Commands::Set {
                 target,
                 feature,
                 value,
-            } => set_workspace_feature(port, &token, &target, &feature, &value).await,
-            Commands::Shutdown => shutdown_server(port, &token).await,
+            } => set_workspace_feature(&server, &target, &feature, &value).await,
+            Commands::Shutdown => shutdown_server(&server).await,
             Commands::Bug { .. } | Commands::Idea { .. } | Commands::Ask { .. } => {
                 unreachable!("handled above")
             }
@@ -1028,16 +913,16 @@ async fn main() {
 
     if let Some(lock) = ServerLock::read() {
         if lock.is_alive() {
-            match add_or_update_workspace(
-                lock.port,
-                &lock.token,
-                &ws_root.to_string_lossy(),
-                flags,
-                cli.collaborator_access_code
-                    .as_ref()
-                    .map(|_| workspace_collaborator_access_code_hash.as_str()),
-            )
-            .await
+            let server = RunningServer::new(lock.port, lock.token.clone());
+            match server
+                .add_or_update_workspace(
+                    &ws_root.to_string_lossy(),
+                    flags,
+                    cli.collaborator_access_code
+                        .as_ref()
+                        .map(|_| workspace_collaborator_access_code_hash.as_str()),
+                )
+                .await
             {
                 Ok(workspace_id) => {
                     // Prefer the running daemon's actual bind host (recorded in

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -913,14 +913,17 @@ async fn main() {
 
     if let Some(lock) = ServerLock::read() {
         if lock.is_alive() {
-            let server = RunningServer::new(lock.port, lock.token.clone());
+            let server = RunningServer::from_lock(lock.clone());
             match server
                 .add_or_update_workspace(
                     &ws_root.to_string_lossy(),
                     flags,
+                    false,
+                    None,
                     cli.collaborator_access_code
                         .as_ref()
                         .map(|_| workspace_collaborator_access_code_hash.as_str()),
+                    None,
                 )
                 .await
             {
@@ -933,11 +936,13 @@ async fn main() {
                     } else {
                         lock.host.clone()
                     };
+                    let active_advertised_host =
+                        lock.advertised_host.as_deref().unwrap_or(&advertised_host);
                     let summary = build_workspace_access_summary(
                         &ws_root,
                         flags,
                         &bind_host,
-                        &advertised_host,
+                        active_advertised_host,
                         lock.port,
                         &workspace_id,
                         initial_path.as_deref(),
@@ -946,7 +951,7 @@ async fn main() {
                     print_workspace_access_summary(&summary);
                     if let Some(base_option) = open_browser_target.as_deref() {
                         let base = if base_option == "local" {
-                            server::featured_base_url(&bind_host, &advertised_host, lock.port)
+                            server::featured_base_url(&bind_host, active_advertised_host, lock.port)
                         } else {
                             base_option.to_string()
                         };

--- a/crates/core/i18n/en.json5
+++ b/crates/core/i18n/en.json5
@@ -28,6 +28,14 @@
     "advertised.auto": "Auto (first LAN address)",
     "advertised.hint": "Which LAN address to show in links and QR codes when bound to 0.0.0.0.",
     "bind.save_failed": "Save failed: {error}",
+    "server.mode.label": "Server",
+    "server.mode.remote": "Connected to a running Markon",
+    "server.mode.embedded": "Running own server",
+    "server.mode.disconnected": "Lost connection to the running Markon",
+    "server.mode.port": "port {port}",
+    "server.action.reconnect": "Reconnect",
+    "server.action.start_local": "Start local server",
+    "server.global_code.remote_unavailable": "Unavailable while connected to an external server",
 
     // ── General — Appearance ─────────────────────────────────
     "sec.appearance": "Appearance",

--- a/crates/core/i18n/ja.json5
+++ b/crates/core/i18n/ja.json5
@@ -28,6 +28,14 @@
     "advertised.hint": "0.0.0.0 にバインドした際、リンクや QR コードに表示する LAN アドレス。",
     "bind.bind_failed": "サーバ起動に失敗：{error}",
     "bind.save_failed": "保存に失敗：{error}",
+    "server.mode.label": "サーバー",
+    "server.mode.remote": "実行中の Markon に接続しています",
+    "server.mode.embedded": "ローカルサーバーを実行しています",
+    "server.mode.disconnected": "実行中の Markon との接続が切れました",
+    "server.mode.port": "ポート {port}",
+    "server.action.reconnect": "再接続",
+    "server.action.start_local": "ローカルサーバーを起動",
+    "server.global_code.remote_unavailable": "外部サーバーへの接続中はグローバルアクセスコードを設定できません",
 
     // ── General — Appearance ─────────────────────────────────
     "sec.appearance": "外観",

--- a/crates/core/i18n/zh_CN.json5
+++ b/crates/core/i18n/zh_CN.json5
@@ -28,6 +28,14 @@
     "advertised.auto": "自动（第一个局域网地址）",
     "advertised.hint": "绑定 0.0.0.0 时，链接与二维码中展示哪个局域网地址。",
     "bind.save_failed": "保存失败：{error}",
+    "server.mode.label": "服务",
+    "server.mode.remote": "已连接到正在运行的 Markon",
+    "server.mode.embedded": "正在运行本地服务",
+    "server.mode.disconnected": "与正在运行的 Markon 连接已断开",
+    "server.mode.port": "端口 {port}",
+    "server.action.reconnect": "重新连接",
+    "server.action.start_local": "启动本地服务",
+    "server.global_code.remote_unavailable": "连接外部服务时不可设置全局访问码",
 
     // ── 全局设置 — 外观 ──────────────────────────────────────
     "sec.appearance": "外观",

--- a/crates/core/src/control.rs
+++ b/crates/core/src/control.rs
@@ -1,0 +1,201 @@
+//! Client for driving an **already-running** markon server over its loopback
+//! management API (`/api/workspace*`, `/api/shutdown`).
+//!
+//! The "only one server per machine" invariant is shared behavior, not a
+//! front-end detail: whoever starts second should hand its workspaces to the
+//! server that is already up rather than start a competing one (which would open
+//! a second connection to the same annotation database — see the single-instance
+//! discussion around [`ServerLock`]). Keeping the client here lets the CLI
+//! (forwarding `markon <dir>` to a running daemon) and the GUI (attaching as a
+//! controller when a daemon is already up) go through one implementation instead
+//! of each re-deriving the HTTP calls.
+//!
+//! All requests target `127.0.0.1` and carry the management token from the lock,
+//! so they satisfy the server's `require_local_and_token` guard.
+
+use crate::workspace::{ServerLock, WorkspaceFlags, WorkspaceInfo};
+
+/// Error talking to a running server's management API.
+#[derive(Debug, thiserror::Error)]
+pub enum ControlError {
+    #[error("request to the running markon server failed: {0}")]
+    Http(#[from] reqwest::Error),
+}
+
+/// A handle to a running server, addressed by its loopback port + management
+/// token (as recorded in the on-disk [`ServerLock`]).
+#[derive(Clone)]
+pub struct RunningServer {
+    port: u16,
+    token: String,
+    client: reqwest::Client,
+}
+
+impl RunningServer {
+    /// Build a handle for an explicit port + token (e.g. from a lock the caller
+    /// already read).
+    pub fn new(port: u16, token: String) -> Self {
+        Self {
+            port,
+            token,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Discover a *live* server from the on-disk lock. Returns `None` when no
+    /// lock exists or the lock is stale (its TCP probe fails), i.e. when the
+    /// caller is free to start its own server.
+    pub fn discover() -> Option<Self> {
+        let lock = ServerLock::read()?;
+        if !lock.is_alive() {
+            return None;
+        }
+        Some(Self::new(lock.port, lock.token))
+    }
+
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("http://127.0.0.1:{}{path}", self.port)
+    }
+
+    /// GET `/api/workspaces` — the running server's live workspace list.
+    pub async fn list_workspaces(&self) -> Result<Vec<WorkspaceInfo>, ControlError> {
+        Ok(self
+            .client
+            .get(self.url("/api/workspaces"))
+            .header("X-Markon-Token", &self.token)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?)
+    }
+
+    /// POST `/api/workspace` — register a workspace, returning its id. The
+    /// collaborator hash is already salted by the caller (empty = inherit /
+    /// no change).
+    pub async fn add_workspace(
+        &self,
+        path: &str,
+        flags: WorkspaceFlags,
+        collaborator_access_code_hash: &str,
+    ) -> Result<String, ControlError> {
+        #[derive(serde::Serialize)]
+        struct Body<'a> {
+            path: &'a str,
+            #[serde(flatten)]
+            flags: WorkspaceFlags,
+            #[serde(skip_serializing_if = "str::is_empty")]
+            collaborator_access_code_hash: &'a str,
+        }
+        #[derive(serde::Deserialize)]
+        struct Resp {
+            id: String,
+        }
+        let resp: Resp = self
+            .client
+            .post(self.url("/api/workspace"))
+            .header("X-Markon-Token", &self.token)
+            .json(&Body {
+                path,
+                flags,
+                collaborator_access_code_hash,
+            })
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await?;
+        Ok(resp.id)
+    }
+
+    /// Register a workspace, or — if `path` is already registered — update its
+    /// access code, returning the existing id. Mirrors the CLI's forward
+    /// semantics so both front-ends behave identically.
+    pub async fn add_or_update_workspace(
+        &self,
+        path: &str,
+        flags: WorkspaceFlags,
+        collaborator_access_code_hash: Option<&str>,
+    ) -> Result<String, ControlError> {
+        let existing = self
+            .list_workspaces()
+            .await?
+            .into_iter()
+            .find(|w| w.path == path);
+        if let Some(existing) = existing {
+            if let Some(hash) = collaborator_access_code_hash {
+                self.set_access_code(&existing.id, Some(hash)).await?;
+            }
+            return Ok(existing.id);
+        }
+        self.add_workspace(path, flags, collaborator_access_code_hash.unwrap_or(""))
+            .await
+    }
+
+    /// PUT `/api/workspace/{id}` — replace a workspace's feature flags wholesale.
+    pub async fn update_flags(&self, id: &str, flags: WorkspaceFlags) -> Result<(), ControlError> {
+        self.client
+            .put(self.url(&format!("/api/workspace/{id}")))
+            .header("X-Markon-Token", &self.token)
+            .json(&flags)
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+
+    /// DELETE `/api/workspace/{id}` — detach a workspace.
+    pub async fn remove_workspace(&self, id: &str) -> Result<(), ControlError> {
+        self.client
+            .delete(self.url(&format!("/api/workspace/{id}")))
+            .header("X-Markon-Token", &self.token)
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+
+    /// PUT `/api/workspace/{id}/access` — set (`Some(hash)`) or leave a
+    /// workspace's collaborator access code. The hash must already be salted
+    /// with the shared per-install salt.
+    pub async fn set_access_code(
+        &self,
+        id: &str,
+        collaborator_access_code_hash: Option<&str>,
+    ) -> Result<(), ControlError> {
+        #[derive(serde::Serialize)]
+        struct Body<'a> {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            collaborator_access_code_hash: Option<&'a str>,
+        }
+        self.client
+            .put(self.url(&format!("/api/workspace/{id}/access")))
+            .header("X-Markon-Token", &self.token)
+            .json(&Body {
+                collaborator_access_code_hash,
+            })
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+
+    /// POST `/api/shutdown` — ask the running server to exit.
+    pub async fn shutdown(&self) -> Result<(), ControlError> {
+        self.client
+            .post(self.url("/api/shutdown"))
+            .header("X-Markon-Token", &self.token)
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+}

--- a/crates/core/src/control.rs
+++ b/crates/core/src/control.rs
@@ -131,6 +131,10 @@ impl RunningServer {
             .into_iter()
             .find(|w| w.path == path);
         if let Some(existing) = existing {
+            // Mirror the embedded registry's `add`, which refreshes the flags of
+            // an already-registered identity: re-adding the same path applies the
+            // supplied flags in both backends so they stay observably identical.
+            self.update_flags(&existing.id, flags).await?;
             if let Some(hash) = collaborator_access_code_hash {
                 self.set_access_code(&existing.id, Some(hash)).await?;
             }

--- a/crates/core/src/control.rs
+++ b/crates/core/src/control.rs
@@ -14,6 +14,7 @@
 //! so they satisfy the server's `require_local_and_token` guard.
 
 use crate::workspace::{ServerLock, WorkspaceFlags, WorkspaceInfo};
+use std::time::Duration;
 
 /// Error talking to a running server's management API.
 #[derive(Debug, thiserror::Error)]
@@ -28,6 +29,8 @@ pub enum ControlError {
 pub struct RunningServer {
     port: u16,
     token: String,
+    bind_host: String,
+    advertised_host: Option<String>,
     client: reqwest::Client,
 }
 
@@ -35,11 +38,30 @@ impl RunningServer {
     /// Build a handle for an explicit port + token (e.g. from a lock the caller
     /// already read).
     pub fn new(port: u16, token: String) -> Self {
+        Self::with_hosts(port, token, String::new(), None)
+    }
+
+    fn with_hosts(
+        port: u16,
+        token: String,
+        bind_host: String,
+        advertised_host: Option<String>,
+    ) -> Self {
         Self {
             port,
             token,
-            client: reqwest::Client::new(),
+            bind_host,
+            advertised_host,
+            client: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(1))
+                .timeout(Duration::from_secs(10))
+                .build()
+                .expect("failed to build markon control client"),
         }
+    }
+
+    pub fn from_lock(lock: ServerLock) -> Self {
+        Self::with_hosts(lock.port, lock.token, lock.host, lock.advertised_host)
     }
 
     /// Discover a *live* server from the on-disk lock. Returns `None` when no
@@ -50,7 +72,7 @@ impl RunningServer {
         if !lock.is_alive() {
             return None;
         }
-        Some(Self::new(lock.port, lock.token))
+        Some(Self::from_lock(lock))
     }
 
     pub fn port(&self) -> u16 {
@@ -59,6 +81,18 @@ impl RunningServer {
 
     pub fn token(&self) -> &str {
         &self.token
+    }
+
+    /// Bind host recorded by the process that owns the server. Empty only for
+    /// legacy lock files; callers should then fall back to their configured
+    /// host. This must drive browser URLs in controller mode — the attached
+    /// GUI's own bind preference may differ from a CLI `--host` override.
+    pub fn bind_host(&self) -> &str {
+        &self.bind_host
+    }
+
+    pub fn advertised_host(&self) -> Option<&str> {
+        self.advertised_host.as_deref()
     }
 
     fn url(&self, path: &str) -> String {
@@ -85,15 +119,21 @@ impl RunningServer {
         &self,
         path: &str,
         flags: WorkspaceFlags,
+        single_file: Option<&str>,
         collaborator_access_code_hash: &str,
+        alias: &str,
     ) -> Result<String, ControlError> {
         #[derive(serde::Serialize)]
         struct Body<'a> {
             path: &'a str,
             #[serde(flatten)]
             flags: WorkspaceFlags,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            single_file: Option<&'a str>,
             #[serde(skip_serializing_if = "str::is_empty")]
             collaborator_access_code_hash: &'a str,
+            #[serde(skip_serializing_if = "str::is_empty")]
+            alias: &'a str,
         }
         #[derive(serde::Deserialize)]
         struct Resp {
@@ -106,7 +146,9 @@ impl RunningServer {
             .json(&Body {
                 path,
                 flags,
+                single_file,
                 collaborator_access_code_hash,
+                alias,
             })
             .send()
             .await?
@@ -116,32 +158,48 @@ impl RunningServer {
         Ok(resp.id)
     }
 
-    /// Register a workspace, or — if `path` is already registered — update its
-    /// access code, returning the existing id. Mirrors the CLI's forward
-    /// semantics so both front-ends behave identically.
+    /// Register a workspace, or update selected properties of an existing
+    /// `(path, single_file)` identity and return its id. GUI callers set
+    /// `update_existing_flags` to mirror `WorkspaceRegistry::add`; CLI callers
+    /// leave it false so opening a path cannot reset configured features.
     pub async fn add_or_update_workspace(
         &self,
         path: &str,
         flags: WorkspaceFlags,
+        update_existing_flags: bool,
+        single_file: Option<&str>,
         collaborator_access_code_hash: Option<&str>,
+        alias: Option<&str>,
     ) -> Result<String, ControlError> {
         let existing = self
             .list_workspaces()
             .await?
             .into_iter()
-            .find(|w| w.path == path);
+            .find(|w| w.path == path && w.single_file.as_deref() == single_file);
         if let Some(existing) = existing {
-            // Mirror the embedded registry's `add`, which refreshes the flags of
-            // an already-registered identity: re-adding the same path applies the
-            // supplied flags in both backends so they stay observably identical.
-            self.update_flags(&existing.id, flags).await?;
+            // GUI registration mirrors the embedded registry's `add`, which
+            // refreshes flags for an existing identity. CLI forwarding passes
+            // false to preserve its historical contract: opening an already
+            // registered path must not reset explicitly configured features.
+            if update_existing_flags {
+                self.update_flags(&existing.id, flags).await?;
+            }
             if let Some(hash) = collaborator_access_code_hash {
                 self.set_access_code(&existing.id, Some(hash)).await?;
             }
+            if let Some(alias) = alias {
+                self.set_alias(&existing.id, alias).await?;
+            }
             return Ok(existing.id);
         }
-        self.add_workspace(path, flags, collaborator_access_code_hash.unwrap_or(""))
-            .await
+        self.add_workspace(
+            path,
+            flags,
+            single_file,
+            collaborator_access_code_hash.unwrap_or(""),
+            alias.unwrap_or(""),
+        )
+        .await
     }
 
     /// PUT `/api/workspace/{id}` — replace a workspace's feature flags wholesale.
@@ -192,6 +250,22 @@ impl RunningServer {
         Ok(())
     }
 
+    /// PUT `/api/workspace/{id}/alias` — set or clear the display alias.
+    pub async fn set_alias(&self, id: &str, alias: &str) -> Result<(), ControlError> {
+        #[derive(serde::Serialize)]
+        struct Body<'a> {
+            alias: &'a str,
+        }
+        self.client
+            .put(self.url(&format!("/api/workspace/{id}/alias")))
+            .header("X-Markon-Token", &self.token)
+            .json(&Body { alias })
+            .send()
+            .await?
+            .error_for_status()?;
+        Ok(())
+    }
+
     /// POST `/api/shutdown` — ask the running server to exit.
     pub async fn shutdown(&self) -> Result<(), ControlError> {
         self.client
@@ -201,5 +275,136 @@ impl RunningServer {
             .await?
             .error_for_status()?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::extract::{Json, State};
+    use axum::http::{HeaderMap, StatusCode};
+    use axum::routing::{get, post, put};
+    use axum::Router;
+    use serde_json::{json, Value};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    async fn capture_add(
+        State(captured): State<Arc<Mutex<Option<Value>>>>,
+        headers: HeaderMap,
+        Json(body): Json<Value>,
+    ) -> Json<Value> {
+        assert_eq!(
+            headers
+                .get("X-Markon-Token")
+                .and_then(|value| value.to_str().ok()),
+            Some("management-token")
+        );
+        *captured.lock().unwrap() = Some(body);
+        Json(json!({ "id": "deadbeef" }))
+    }
+
+    #[tokio::test]
+    async fn add_workspace_carries_single_file_scope_and_alias() {
+        let captured = Arc::new(Mutex::new(None));
+        let app = Router::new()
+            .route("/api/workspace", post(capture_add))
+            .with_state(captured.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let task = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let server = RunningServer::new(port, "management-token".into());
+        let id = server
+            .add_workspace(
+                "/tmp/docs",
+                WorkspaceFlags::default(),
+                Some("note.md"),
+                "hash",
+                "Pinned note",
+            )
+            .await
+            .unwrap();
+        assert_eq!(id, "deadbeef");
+        let body = captured.lock().unwrap().take().unwrap();
+        assert_eq!(body["path"], "/tmp/docs");
+        assert_eq!(body["single_file"], "note.md");
+        assert_eq!(body["collaborator_access_code_hash"], "hash");
+        assert_eq!(body["alias"], "Pinned note");
+        task.abort();
+    }
+
+    #[test]
+    fn running_server_preserves_active_hosts_from_lock() {
+        let server = RunningServer::from_lock(ServerLock {
+            port: 6419,
+            token: "token".into(),
+            host: "0.0.0.0".into(),
+            advertised_host: Some(String::new()),
+        });
+        assert_eq!(server.bind_host(), "0.0.0.0");
+        assert_eq!(server.advertised_host(), Some(""));
+    }
+
+    async fn existing_workspaces() -> Json<Value> {
+        Json(json!([{
+            "id": "deadbeef",
+            "path": "/tmp/docs",
+            "enable_search": true,
+            "enable_viewed": false,
+            "enable_edit": false,
+            "enable_live": false,
+            "enable_chat": false,
+            "shared_annotation": false,
+            "search_ready": true,
+            "ephemeral": false,
+            "alias": ""
+        }]))
+    }
+
+    async fn count_flag_update(State(count): State<Arc<AtomicUsize>>) -> StatusCode {
+        count.fetch_add(1, Ordering::Relaxed);
+        StatusCode::OK
+    }
+
+    #[tokio::test]
+    async fn existing_workspace_flag_update_is_an_explicit_policy() {
+        let count = Arc::new(AtomicUsize::new(0));
+        let app = Router::new()
+            .route("/api/workspaces", get(existing_workspaces))
+            .route("/api/workspace/{id}", put(count_flag_update))
+            .with_state(count.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let task = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let server = RunningServer::new(port, "management-token".into());
+
+        let id = server
+            .add_or_update_workspace(
+                "/tmp/docs",
+                WorkspaceFlags::default(),
+                false,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(id, "deadbeef");
+        assert_eq!(count.load(Ordering::Relaxed), 0);
+
+        server
+            .add_or_update_workspace(
+                "/tmp/docs",
+                WorkspaceFlags::default(),
+                true,
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        assert_eq!(count.load(Ordering::Relaxed), 1);
+        task.abort();
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod chat;
+pub mod control;
 pub mod git;
 pub mod i18n;
 pub mod net;

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -967,6 +967,10 @@ pub async fn start(config: ServerConfig) -> Result<(), String> {
             "/api/workspace/{id}/access",
             axum::routing::put(update_workspace_access_handler),
         )
+        .route(
+            "/api/workspace/{id}/alias",
+            axum::routing::put(handle_workspace_update_alias),
+        )
         .route("/api/workspaces", get(list_workspaces_handler))
         .route("/api/admin/bootstrap", post(create_admin_bootstrap_handler))
         .route("/api/shutdown", post(shutdown_handler))
@@ -1177,18 +1181,23 @@ pub async fn start(config: ServerConfig) -> Result<(), String> {
             port: addr.port(),
             token: token.as_ref().clone(),
             host: host.clone(),
+            advertised_host: Some(advertised_host.clone()),
         })
         .write()
         {
             tracing::warn!("failed to write lock file: {e}");
         }
-        struct LockGuard;
+        struct LockGuard {
+            token: String,
+        }
         impl Drop for LockGuard {
             fn drop(&mut self) {
-                ServerLock::remove();
+                ServerLock::remove_if_owned(&self.token);
             }
         }
-        LockGuard
+        LockGuard {
+            token: token.as_ref().clone(),
+        }
     };
 
     // Helper: build a full URL from a base option string.
@@ -3466,7 +3475,11 @@ struct AddWorkspaceRequest {
     #[serde(flatten)]
     flags: WorkspaceFlags,
     #[serde(default)]
+    single_file: Option<String>,
+    #[serde(default)]
     collaborator_access_code_hash: String,
+    #[serde(default)]
+    alias: String,
 }
 
 #[derive(Deserialize)]
@@ -3493,12 +3506,25 @@ async fn add_workspace_handler(
         Ok(p) => p,
         Err(e) => return (StatusCode::BAD_REQUEST, format!("Invalid path: {e}")).into_response(),
     };
+    if let Some(single_file) = req.single_file.as_deref() {
+        let mut components = FsPath::new(single_file).components();
+        let exactly_one_normal_component =
+            matches!(components.next(), Some(std::path::Component::Normal(_)))
+                && components.next().is_none();
+        if !exactly_one_normal_component {
+            return (
+                StatusCode::BAD_REQUEST,
+                "single_file must be one workspace-relative file name",
+            )
+                .into_response();
+        }
+    }
     let id = state.workspace_registry.add(WorkspaceConfig {
         path,
         flags: req.flags,
-        single_file: None,
+        single_file: req.single_file,
         collaborator_access_code_hash: req.collaborator_access_code_hash,
-        alias: String::new(),
+        alias: req.alias,
     });
     Json(AddWorkspaceResponse { id }).into_response()
 }
@@ -6979,6 +7005,73 @@ mod tests {
             collaborator_access_code_hash: String::new(),
             ..Default::default()
         })
+    }
+
+    #[tokio::test]
+    async fn management_add_preserves_single_file_capability_and_alias() {
+        use axum::body::Body;
+        use axum::http::Request;
+
+        let root = tempfile::tempdir().unwrap();
+        std::fs::write(root.path().join("note.md"), "# note").unwrap();
+        std::fs::write(root.path().join("secret.md"), "secret").unwrap();
+        let registry = Arc::new(WorkspaceRegistry::new("single-file-api".into()));
+        let app = Router::new()
+            .route("/api/workspace", post(add_workspace_handler))
+            .with_state(test_state(registry.clone()));
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/workspace")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "path": root.path(),
+                            "single_file": "note.md",
+                            "alias": "Pinned note"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let id = serde_json::from_slice::<serde_json::Value>(&body).unwrap()["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let info = registry
+            .info_list()
+            .into_iter()
+            .find(|info| info.id == id)
+            .unwrap();
+        assert!(info.ephemeral);
+        assert_eq!(info.single_file.as_deref(), Some("note.md"));
+        assert_eq!(info.alias, "Pinned note");
+        let entry = registry.get(&id).unwrap();
+        assert!(entry.fs.resolve_served("note.md").is_ok());
+        assert!(entry.fs.resolve_served("secret.md").is_err());
+
+        let invalid = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/workspace")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({ "path": root.path(), "single_file": "../secret.md" }).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(invalid.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(registry.info_list().len(), 1);
     }
 
     async fn spawn_collaboration_test_server(

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -1,5 +1,5 @@
 use crate::server::{ServerConfig, WorkspaceInit};
-use crate::workspace::{generate_token, PersistHook, WorkspaceFlags, WorkspaceRegistry};
+use crate::workspace::{generate_token, PersistHook, WorkspaceFlags, WorkspaceInfo};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -358,6 +358,62 @@ impl AppSettings {
         home.join(".markon").join("settings.json")
     }
 
+    fn settings_write_lock_path_at(home: &Path) -> PathBuf {
+        home.join(".markon").join("settings.write.lock")
+    }
+
+    /// Serialize read/merge/write transactions across the GUI and a daemon.
+    /// Atomic rename prevents torn JSON, but by itself does not prevent two
+    /// processes with stale in-memory snapshots from overwriting each other's
+    /// fields. This sidecar lock closes that lost-update window.
+    fn with_settings_write_lock<T>(
+        home: &Path,
+        operation: impl FnOnce() -> Result<T, String>,
+    ) -> Result<T, String> {
+        let path = Self::settings_write_lock_path_at(home);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|error| error.to_string())?;
+        }
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let lock = options.open(&path).map_err(|error| error.to_string())?;
+        lock.lock().map_err(|error| error.to_string())?;
+        let result = operation();
+        let unlock_result = lock.unlock().map_err(|error| error.to_string());
+        match result {
+            Ok(value) => {
+                unlock_result?;
+                Ok(value)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Read a complete settings snapshot for a locked merge. A malformed file
+    /// is never overwritten here: it may be the last recoverable source of the
+    /// persistent salt/workspace identities.
+    fn read_for_locked_merge_at(home: &Path) -> Result<Option<Self>, String> {
+        let path = Self::settings_path_at(home);
+        let raw = match std::fs::read_to_string(&path) {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => return Err(error.to_string()),
+        };
+        let mut settings = serde_json::from_str::<Self>(&raw).map_err(|error| {
+            format!(
+                "refusing to overwrite malformed settings {}: {error}",
+                path.display()
+            )
+        })?;
+        settings.normalize();
+        Ok(Some(settings))
+    }
+
     pub fn example_workspace_path_at(home: &Path) -> PathBuf {
         home.join(".markon").join("example")
     }
@@ -530,7 +586,7 @@ impl AppSettings {
             self.web_editor_theme = "follow".to_string();
         }
     }
-    pub(crate) fn save_at(&self, home: &Path) -> Result<(), String> {
+    fn save_at_unlocked(&self, home: &Path) -> Result<(), String> {
         let p = Self::settings_path_at(home);
         if let Some(parent) = p.parent() {
             let _ = std::fs::create_dir_all(parent);
@@ -546,6 +602,10 @@ impl AppSettings {
         Ok(())
     }
 
+    pub(crate) fn save_at(&self, home: &Path) -> Result<(), String> {
+        Self::with_settings_write_lock(home, || self.save_at_unlocked(home))
+    }
+
     /// True when at least one chat provider has an api_key set. Used to
     /// gate the "plaintext key on disk" warning so we don't spam users
     /// who haven't configured chat at all.
@@ -557,6 +617,32 @@ impl AppSettings {
     pub fn save(&self) -> Result<(), String> {
         let home = dirs::home_dir().expect("HOME directory required");
         self.save_at(&home)
+    }
+
+    /// Save GUI-owned preferences while the live server registry remains
+    /// authoritative for workspace membership/flags and its global access-code
+    /// hash. This applies both to an embedded server and to an attached daemon.
+    /// Merge those fields from disk under the cross-process write lock before
+    /// replacing the file, and update this in-memory snapshot to the result.
+    pub fn save_preserving_server_owned_state(&mut self) -> Result<(), String> {
+        let home = dirs::home_dir().expect("HOME directory required");
+        self.save_preserving_server_owned_state_at(&home)
+    }
+
+    pub(crate) fn save_preserving_server_owned_state_at(
+        &mut self,
+        home: &Path,
+    ) -> Result<(), String> {
+        Self::with_settings_write_lock(home, || {
+            if let Some(latest) = Self::read_for_locked_merge_at(home)? {
+                self.workspaces = latest.workspaces;
+                self.collaborator_access_code_hash = latest.collaborator_access_code_hash;
+                if !latest.salt.is_empty() {
+                    self.salt = latest.salt;
+                }
+            }
+            self.save_at_unlocked(home)
+        })
     }
     pub fn to_server_config(&self, port: u16) -> ServerConfig {
         let initial_workspaces: Vec<WorkspaceInit> = self
@@ -622,10 +708,32 @@ impl AppSettings {
     /// GUI both wire this so workspace changes initiated from either side
     /// end up with the same persistent state.
     pub fn persist_hook(settings: Arc<Mutex<AppSettings>>) -> PersistHook {
+        let home = dirs::home_dir().expect("HOME directory required");
+        Self::persist_hook_at(settings, home)
+    }
+
+    fn persist_hook_at(settings: Arc<Mutex<AppSettings>>, home: PathBuf) -> PersistHook {
         Arc::new(move |reg| {
             let mut s = settings.lock().unwrap();
-            s.sync_from_registry(reg);
-            let _ = s.save();
+            let infos = reg.info_list();
+            let result = Self::with_settings_write_lock(&home, || {
+                // A controller GUI may have changed non-workspace preferences
+                // since this server loaded its own snapshot. Start from the
+                // newest complete file, then overlay only the registry-owned
+                // workspace state so neither process loses the other's fields.
+                let mut merged =
+                    Self::read_for_locked_merge_at(&home)?.unwrap_or_else(|| s.clone());
+                if merged.salt.is_empty() {
+                    merged.salt = s.salt.clone();
+                }
+                merged.sync_from_workspace_infos(infos.clone());
+                merged.save_at_unlocked(&home)?;
+                *s = merged;
+                Ok(())
+            });
+            if let Err(error) = result {
+                tracing::warn!(%error, "failed to persist workspace registry");
+            }
         })
     }
 
@@ -650,12 +758,11 @@ impl AppSettings {
         before - self.workspaces.len()
     }
 
-    /// Overwrite `workspaces` with the current registry contents, including
-    /// temporary single-file entries. Their startup retention is controlled by
-    /// `auto_remove_single_file_workspaces`.
-    pub(crate) fn sync_from_registry(&mut self, registry: &WorkspaceRegistry) {
-        self.workspaces = registry
-            .info_list()
+    /// Refresh only the fields owned by the live server registry. Attached GUI
+    /// controllers use this after a remote list call to keep their in-memory
+    /// snapshot aligned without writing the file a second time.
+    pub fn sync_from_workspace_infos(&mut self, infos: Vec<WorkspaceInfo>) {
+        self.workspaces = infos
             .into_iter()
             .map(|info| WorkspaceSettings {
                 path: info.path,
@@ -765,7 +872,7 @@ impl AppSettings {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::workspace::{hash_id, WorkspaceConfig};
+    use crate::workspace::{hash_id, WorkspaceConfig, WorkspaceRegistry};
 
     /// Self-cleaning tempdir; each test gets an isolated `home` so they can
     /// run in parallel without touching the real `HOME` env var.
@@ -1197,7 +1304,7 @@ mod tests {
         });
 
         let mut s = AppSettings::default();
-        s.sync_from_registry(&reg);
+        s.sync_from_workspace_infos(reg.info_list());
 
         assert_eq!(s.workspaces.len(), 2);
         assert_eq!(s.workspaces[0].path, ws_path.to_string_lossy());
@@ -1440,5 +1547,71 @@ mod tests {
         let config = s2.to_server_config(6419);
         assert_eq!(config.advertised_host, "192.168.1.20");
         assert_eq!(config.trusted_hosts, ["https://md.example.com"]);
+    }
+
+    #[test]
+    fn attached_gui_and_daemon_merge_settings_without_lost_updates() {
+        let home = TempHome::new("settings-merge");
+        let old_root = home.path().join("old");
+        let live_root = home.path().join("live");
+        std::fs::create_dir_all(&old_root).unwrap();
+        std::fs::create_dir_all(&live_root).unwrap();
+
+        let base = AppSettings {
+            salt: "persistent-salt".into(),
+            collaborator_access_code_hash: "server-hash".into(),
+            workspaces: vec![WorkspaceSettings {
+                path: old_root.to_string_lossy().into_owned(),
+                flags: WorkspaceFlags::default(),
+                ..WorkspaceSettings::default()
+            }],
+            ..AppSettings::default()
+        };
+        base.save_at(home.path()).unwrap();
+
+        // The daemon owns the live registry and writes it through its persist
+        // hook. Its in-memory settings snapshot starts with the old workspace.
+        let daemon_settings = Arc::new(Mutex::new(base.clone()));
+        let registry = WorkspaceRegistry::new(base.salt.clone());
+        registry.set_persist_hook(AppSettings::persist_hook_at(
+            daemon_settings.clone(),
+            home.path().to_path_buf(),
+        ));
+        let id = registry.add(WorkspaceConfig {
+            path: live_root.clone(),
+            flags: WorkspaceFlags::default(),
+            single_file: None,
+            collaborator_access_code_hash: String::new(),
+            alias: String::new(),
+        });
+
+        // A stale controller snapshot changes a GUI-owned preference. Its save
+        // must retain the daemon's current workspace/global-code/salt fields.
+        let mut gui_settings = base.clone();
+        gui_settings.theme = "dark".into();
+        gui_settings.workspaces = base.workspaces.clone();
+        gui_settings.collaborator_access_code_hash = "stale-hash".into();
+        gui_settings
+            .save_preserving_server_owned_state_at(home.path())
+            .unwrap();
+        let after_gui = AppSettings::load_at(home.path());
+        assert_eq!(after_gui.theme, "dark");
+        assert_eq!(after_gui.salt, "persistent-salt");
+        assert_eq!(after_gui.collaborator_access_code_hash, "server-hash");
+        assert_eq!(after_gui.workspaces.len(), 1);
+        assert_eq!(after_gui.workspaces[0].path, live_root.to_string_lossy());
+
+        // A later daemon mutation starts from the newest file, overlays only
+        // registry state, and therefore cannot roll the GUI preference back.
+        let flags = WorkspaceFlags {
+            enable_search: true,
+            ..WorkspaceFlags::default()
+        };
+        assert!(registry.update_flags(&id, flags));
+        let final_settings = AppSettings::load_at(home.path());
+        assert_eq!(final_settings.theme, "dark");
+        assert_eq!(final_settings.salt, "persistent-salt");
+        assert_eq!(final_settings.workspaces[0].flags, flags);
+        assert_eq!(daemon_settings.lock().unwrap().theme, "dark");
     }
 }

--- a/crates/core/src/workspace.rs
+++ b/crates/core/src/workspace.rs
@@ -132,7 +132,7 @@ impl WorkspaceEntry {
 /// because it's built from [`WorkspaceEntry`] state, but its only public
 /// contract is the wire format — see `crate::server::api` for the canonical
 /// re-export.
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct WorkspaceInfo {
     pub id: String,
     /// Workspace **serving root** — what `/{id}/…` resolves under. For
@@ -735,7 +735,7 @@ fn directory_live_reload_path(root: &Path, path: &Path) -> Option<String> {
     Some(path_to_forward_slash(rel))
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct ServerLock {
     pub port: u16,
     pub token: String,
@@ -746,6 +746,10 @@ pub struct ServerLock {
     /// which callers treat as loopback.
     #[serde(default)]
     pub host: String,
+    /// Advertised host active in the owning server process. `None` denotes a
+    /// legacy lock file; `Some("")` is the valid automatic-LAN selection.
+    #[serde(default)]
+    pub advertised_host: Option<String>,
 }
 impl ServerLock {
     pub(crate) fn path() -> PathBuf {
@@ -755,11 +759,10 @@ impl ServerLock {
             .join("server.lock")
     }
     pub(crate) fn write(&self) -> std::io::Result<()> {
-        let path = Self::path();
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        write_file_user_private(&path, serde_json::to_string(self).unwrap().as_bytes())
+        Self::with_write_lock(|| {
+            let path = Self::path();
+            write_file_user_private(&path, serde_json::to_string(self).unwrap().as_bytes())
+        })
     }
     pub fn read() -> Option<Self> {
         let path = Self::path();
@@ -783,8 +786,47 @@ impl ServerLock {
             }
         }
     }
-    pub(crate) fn remove() {
-        let _ = std::fs::remove_file(Self::path());
+    fn with_write_lock<T>(operation: impl FnOnce() -> std::io::Result<T>) -> std::io::Result<T> {
+        let path = Self::path();
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        std::fs::create_dir_all(parent)?;
+        let lock_path = parent.join("server.write.lock");
+        let mut options = std::fs::OpenOptions::new();
+        options.read(true).write(true).create(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let lock = options.open(lock_path)?;
+        lock.lock()?;
+        let result = operation();
+        let unlock_result = lock.unlock();
+        match result {
+            Ok(value) => {
+                unlock_result?;
+                Ok(value)
+            }
+            Err(error) => Err(error),
+        }
+    }
+
+    /// Remove the discovery file only if it still belongs to this server. A
+    /// newer process may have replaced it; unconditional cleanup would then
+    /// make the live server undiscoverable. The sidecar lock makes the
+    /// compare-and-remove transaction race-free against `write()`.
+    pub(crate) fn remove_if_owned(token: &str) {
+        let _ = Self::with_write_lock(|| {
+            let owned = Self::read().is_some_and(|lock| lock.token == token);
+            if owned {
+                match std::fs::remove_file(Self::path()) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(error),
+                }
+            }
+            Ok(())
+        });
     }
     pub fn is_alive(&self) -> bool {
         let connect_host = if crate::net::host_is_wildcard_v6(&self.host) {
@@ -975,6 +1017,7 @@ mod tests {
         assert_eq!(lock.port, 6419);
         assert_eq!(lock.token, "abc");
         assert_eq!(lock.host, "");
+        assert_eq!(lock.advertised_host, None);
     }
 
     #[test]
@@ -983,12 +1026,14 @@ mod tests {
             port: 6419,
             token: "tok".into(),
             host: "0.0.0.0".into(),
+            advertised_host: Some("192.168.1.20".into()),
         };
         let json = serde_json::to_string(&lock).unwrap();
         let back: ServerLock = serde_json::from_str(&json).unwrap();
         assert_eq!(back.host, "0.0.0.0");
         assert_eq!(back.port, 6419);
         assert_eq!(back.token, "tok");
+        assert_eq!(back.advertised_host.as_deref(), Some("192.168.1.20"));
     }
 
     /// Block until the entry's search index is populated (it's built on a

--- a/crates/core/src/workspace.rs
+++ b/crates/core/src/workspace.rs
@@ -132,7 +132,7 @@ impl WorkspaceEntry {
 /// because it's built from [`WorkspaceEntry`] state, but its only public
 /// contract is the wire format — see `crate::server::api` for the canonical
 /// re-export.
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct WorkspaceInfo {
     pub id: String,
     /// Workspace **serving root** — what `/{id}/…` resolves under. For
@@ -148,7 +148,7 @@ pub struct WorkspaceInfo {
     pub ephemeral: bool,
     /// `Some(filename)` only when ephemeral, for callers that want to display
     /// or re-derive the URL. Omitted from the wire format when None.
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub single_file: Option<String>,
     /// Per-workspace collaborator access-code hash (empty = inherit the server code).
     #[serde(default, skip_serializing_if = "String::is_empty")]

--- a/crates/gui/src/commands.rs
+++ b/crates/gui/src/commands.rs
@@ -1,10 +1,14 @@
+use crate::server_manager::{ServerBackend, ServerManager};
 use crate::AppState;
 use markon_core::chat::{config::ProviderKind, models};
+use markon_core::control::{ControlError, RunningServer};
 use markon_core::i18n;
 use markon_core::net::{available_bind_hosts, host_in_list, BindHostOption};
 use markon_core::server;
 use markon_core::settings::{AppSettings, PortMode};
-use markon_core::workspace::{expand_and_canonicalize, WorkspaceConfig, WorkspaceFlags};
+use markon_core::workspace::{
+    expand_and_canonicalize, WorkspaceConfig, WorkspaceFlags, WorkspaceInfo,
+};
 use serde::Deserialize;
 use std::path::PathBuf;
 use std::sync::atomic::Ordering;
@@ -20,14 +24,59 @@ const MARKON_REPO: &str = "kookyleo/markon";
 fn server_status_payload(state: &State<AppState>) -> serde_json::Value {
     let server = state.server.lock().unwrap();
     let bind_host = state.settings.lock().unwrap().host.clone();
-    let hosts = available_bind_hosts();
-    let host_available = host_in_list(&bind_host, &hosts);
+    let is_remote = server.is_remote();
+    // In remote mode this GUI doesn't bind anything, so the local bind-host
+    // availability check is meaningless — report available so no stale banner
+    // shows. The frontend keys off `mode` to render the connection state.
+    let host_available = if is_remote {
+        true
+    } else {
+        host_in_list(&bind_host, &available_bind_hosts())
+    };
     serde_json::json!({
         "running": server.is_running(),
         "error": server.last_error(),
         "host": bind_host,
         "port": server.port(),
         "host_available": host_available,
+        "mode": server.mode(),
+    })
+}
+
+/// Distinguishable error prefix for a failed remote-control call, so the
+/// frontend can surface the reconnect / start-local recovery affordances.
+fn remote_err(e: ControlError) -> String {
+    format!("remote-server-error: {e}")
+}
+
+/// ONE mapping from a `WorkspaceInfo` to the workspace-panel JSON, shared by the
+/// embedded (in-process registry) and remote (control API) list paths so every
+/// field the panel reads stays identical across both modes.
+fn workspace_panel_json(info: WorkspaceInfo, browser_base: &str) -> serde_json::Value {
+    let url = server::build_workspace_url(
+        browser_base,
+        &server::workspace_url_path(&info.id, None),
+    );
+    serde_json::json!({
+        "id": info.id,
+        "path": info.path,
+        "url": url,
+        "enable_search": info.flags.enable_search,
+        "enable_viewed": info.flags.enable_viewed,
+        "enable_edit": info.flags.enable_edit,
+        "enable_live": info.flags.enable_live,
+        "enable_chat": info.flags.enable_chat,
+        "shared_annotation": info.flags.shared_annotation,
+        // Non-zero iff a per-workspace collaborator access code is set. The
+        // stored value is the full 64-hex digest, so this is only a set/not-set
+        // signal (the panel draws a fixed dot count); not the digest itself.
+        "collaborator_access_code_len": info.collaborator_access_code_hash.chars().count(),
+        "search_ready": info.search_ready,
+        // Lets the Settings UI filter out Open-With single-file workspaces.
+        "ephemeral": info.ephemeral,
+        "single_file": info.single_file,
+        // Optional short display name (empty = none).
+        "alias": info.alias,
     })
 }
 
@@ -140,7 +189,13 @@ fn restart_server_and_broadcast(
     let settings = state.settings.lock().unwrap().clone();
     let config = settings.to_server_config(effective_port(&settings));
     let persist = AppSettings::persist_hook(state.settings.clone());
-    let start_result = state.server.lock().unwrap().start(config, Some(persist));
+    // Only an embedded server has a lifecycle we own. In remote mode there is
+    // nothing to (re)start — the settings that would rebind a server don't
+    // apply to a server another process is running; just re-broadcast status.
+    let start_result = match &mut *state.server.lock().unwrap() {
+        ServerBackend::Embedded(m) => m.start(config, Some(persist)),
+        ServerBackend::Remote(_) => Ok(()),
+    };
     // Always broadcast — even on failure UI needs the new (host, error) so
     // the banner state and toast don't lag the persisted settings.
     let _ = app.emit("server-status-changed", server_status_payload(state));
@@ -244,7 +299,10 @@ fn is_example_workspace_path(path: &str) -> bool {
 }
 
 #[tauri::command]
-pub fn add_workspace(path: String, state: State<AppState>) -> Result<serde_json::Value, String> {
+pub async fn add_workspace(
+    path: String,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
     let canonical = expand_and_canonicalize(&path).map_err(|e| format!("Invalid path: {e}"))?;
     let flags = {
         let settings = state.settings.lock().unwrap();
@@ -257,16 +315,39 @@ pub fn add_workspace(path: String, state: State<AppState>) -> Result<serde_json:
             shared_annotation: settings.default_shared_annotation,
         }
     };
-    let server = state.server.lock().unwrap();
-    let id = server.registry.add(WorkspaceConfig {
-        path: canonical,
-        flags,
-        single_file: None,
-        collaborator_access_code_hash: String::new(),
-        alias: String::new(),
-    });
-    let port = server.port();
-    drop(server);
+    // Embedded: add to the in-process registry under the lock. Remote: clone the
+    // handle out, drop the (non-Send) guard, then await the control call.
+    enum Dispatch {
+        Embedded(String, u16),
+        Remote(RunningServer),
+    }
+    let dispatch = {
+        let backend = state.server.lock().unwrap();
+        match &*backend {
+            ServerBackend::Embedded(m) => {
+                let id = m.registry.add(WorkspaceConfig {
+                    path: canonical.clone(),
+                    flags,
+                    single_file: None,
+                    collaborator_access_code_hash: String::new(),
+                    alias: String::new(),
+                });
+                Dispatch::Embedded(id, m.port())
+            }
+            ServerBackend::Remote(r) => Dispatch::Remote(r.clone()),
+        }
+    };
+    let (id, port) = match dispatch {
+        Dispatch::Embedded(id, port) => (id, port),
+        Dispatch::Remote(remote) => {
+            let path_str = canonical.to_string_lossy().to_string();
+            let id = remote
+                .add_or_update_workspace(&path_str, flags, None)
+                .await
+                .map_err(remote_err)?;
+            (id, remote.port())
+        }
+    };
     let url = server::build_workspace_url(
         &browser_base_url_for_state(&state, port),
         &server::workspace_url_path(&id, None),
@@ -307,9 +388,9 @@ pub struct UpdateWorkspaceRequest {
 /// Update a workspace's feature flags in place. `registry.update_flags` fires
 /// the persist hook, so the change is written to settings and survives restart.
 #[tauri::command]
-pub fn update_workspace(
+pub async fn update_workspace(
     request: UpdateWorkspaceRequest,
-    state: State<AppState>,
+    state: State<'_, AppState>,
 ) -> Result<(), String> {
     let flags = flags_from_params(
         request.enable_search,
@@ -319,26 +400,60 @@ pub fn update_workspace(
         request.enable_chat,
         request.shared_annotation,
     );
-    let server = state.server.lock().unwrap();
-    if !server.registry.update_flags(&request.id, flags) {
-        return Err(format!("Workspace {} not found", request.id));
-    }
-    Ok(())
+    let remote = {
+        let backend = state.server.lock().unwrap();
+        match &*backend {
+            ServerBackend::Embedded(m) => {
+                if !m.registry.update_flags(&request.id, flags) {
+                    return Err(format!("Workspace {} not found", request.id));
+                }
+                return Ok(());
+            }
+            ServerBackend::Remote(r) => r.clone(),
+        }
+    };
+    remote
+        .update_flags(&request.id, flags)
+        .await
+        .map_err(remote_err)
 }
 
 #[tauri::command]
-pub fn remove_workspace(id: String, state: State<AppState>) -> Result<(), String> {
-    let server = state.server.lock().unwrap();
-    let is_example = server
-        .registry
-        .info_list()
+pub async fn remove_workspace(id: String, state: State<'_, AppState>) -> Result<(), String> {
+    // `is_example` gates persisting the "example hidden" onboarding flag, so the
+    // bundled sample doesn't re-appear after the user removes it.
+    let remote = {
+        let backend = state.server.lock().unwrap();
+        match &*backend {
+            ServerBackend::Embedded(m) => {
+                let is_example = m
+                    .registry
+                    .info_list()
+                    .into_iter()
+                    .find(|info| info.id == id)
+                    .is_some_and(|info| is_example_workspace_path(&info.path));
+                if !m.registry.remove(&id) {
+                    return Err(format!("Workspace {id} not found"));
+                }
+                drop(backend);
+                if is_example {
+                    let mut settings = state.settings.lock().unwrap();
+                    settings.example_workspace_hidden = true;
+                    settings.save()?;
+                }
+                return Ok(());
+            }
+            ServerBackend::Remote(r) => r.clone(),
+        }
+    };
+    let is_example = remote
+        .list_workspaces()
+        .await
+        .map_err(remote_err)?
         .into_iter()
         .find(|info| info.id == id)
         .is_some_and(|info| is_example_workspace_path(&info.path));
-    if !server.registry.remove(&id) {
-        return Err(format!("Workspace {id} not found"));
-    }
-    drop(server);
+    remote.remove_workspace(&id).await.map_err(remote_err)?;
     if is_example {
         let mut settings = state.settings.lock().unwrap();
         settings.example_workspace_hidden = true;
@@ -347,47 +462,34 @@ pub fn remove_workspace(id: String, state: State<AppState>) -> Result<(), String
     Ok(())
 }
 
-/// List all active workspaces with their IDs and URLs.
+/// List all active workspaces with their IDs and URLs. Works in both modes via
+/// the shared `workspace_panel_json` mapping over `WorkspaceInfo`.
 #[tauri::command]
-pub fn get_workspaces(state: State<AppState>) -> Vec<serde_json::Value> {
-    let (port, workspaces) = {
-        let server = state.server.lock().unwrap();
-        (server.port(), server.registry.info_list())
+pub async fn get_workspaces(
+    state: State<'_, AppState>,
+) -> Result<Vec<serde_json::Value>, String> {
+    enum Dispatch {
+        Embedded(u16, Vec<WorkspaceInfo>),
+        Remote(RunningServer, u16),
+    }
+    let dispatch = {
+        let backend = state.server.lock().unwrap();
+        match &*backend {
+            ServerBackend::Embedded(m) => Dispatch::Embedded(m.port(), m.registry.info_list()),
+            ServerBackend::Remote(r) => Dispatch::Remote(r.clone(), r.port()),
+        }
+    };
+    let (port, infos) = match dispatch {
+        Dispatch::Embedded(port, infos) => (port, infos),
+        Dispatch::Remote(remote, port) => {
+            (port, remote.list_workspaces().await.map_err(remote_err)?)
+        }
     };
     let browser_base = browser_base_url_for_state(&state, port);
-    workspaces
+    Ok(infos
         .into_iter()
-        .map(|info| {
-            let url = server::build_workspace_url(
-                &browser_base,
-                &server::workspace_url_path(&info.id, None),
-            );
-            serde_json::json!({
-                "id": info.id,
-                "path": info.path,
-                "url": url,
-                "enable_search": info.flags.enable_search,
-                "enable_viewed": info.flags.enable_viewed,
-                "enable_edit": info.flags.enable_edit,
-                "enable_live": info.flags.enable_live,
-                "enable_chat": info.flags.enable_chat,
-                "shared_annotation": info.flags.shared_annotation,
-                // Non-zero iff a per-workspace collaborator access code is set.
-                // The stored value is now the full 64-hex digest (not truncated
-                // to the code length), so this is only a "set / not set" signal;
-                // the panel renders a fixed number of • for any set code and no
-                // longer reveals the real length. Not the digest itself.
-                "collaborator_access_code_len": info.collaborator_access_code_hash.chars().count(),
-                "search_ready": info.search_ready,
-                // Surfaced so the Settings UI can filter out Open-With
-                // single-file workspaces (see `ui/index.html: refreshWorkspaces`).
-                "ephemeral": info.ephemeral,
-                "single_file": info.single_file,
-                // Optional short display name (empty = none).
-                "alias": info.alias,
-            })
-        })
-        .collect()
+        .map(|info| workspace_panel_json(info, &browser_base))
+        .collect())
 }
 
 /// Set (or clear, with an empty string) a workspace's alias. Per-workspace and
@@ -398,16 +500,19 @@ pub fn set_alias(
     alias: String,
     state: State<AppState>,
 ) -> Result<(), String> {
-    if state
-        .server
-        .lock()
-        .unwrap()
-        .registry
-        .set_alias(&workspace_id, alias.trim())
-    {
-        Ok(())
-    } else {
-        Err("workspace not found".into())
+    match &*state.server.lock().unwrap() {
+        ServerBackend::Embedded(m) => {
+            if m.registry.set_alias(&workspace_id, alias.trim()) {
+                Ok(())
+            } else {
+                Err("workspace not found".into())
+            }
+        }
+        // The control API has no alias endpoint, so an alias can't be pushed to
+        // a server another process is running.
+        ServerBackend::Remote(_) => {
+            Err("setting an alias is not supported while connected to an external server".into())
+        }
     }
 }
 
@@ -416,16 +521,20 @@ pub fn open_url(url: String, state: State<AppState>) -> Result<(), String> {
     let server = state.server.lock().unwrap();
     let base = browser_base_url_for_state(&state, server.port());
     let markon_prefix = format!("{}/", base.trim_end_matches('/'));
-    let target = if url.starts_with(&markon_prefix) {
-        let parsed = url::Url::parse(&url).map_err(|error| error.to_string())?;
-        let mut redirect = parsed.path().to_string();
-        if let Some(query) = parsed.query() {
-            redirect.push('?');
-            redirect.push_str(query);
+    // Only an embedded server can mint a one-time admin bootstrap (its
+    // AdminBootstrapStore). For a remote server, bootstrap belongs to the owning
+    // process, so open the plain URL (no admin session) instead of rewriting.
+    let target = match &*server {
+        ServerBackend::Embedded(m) if url.starts_with(&markon_prefix) => {
+            let parsed = url::Url::parse(&url).map_err(|error| error.to_string())?;
+            let mut redirect = parsed.path().to_string();
+            if let Some(query) = parsed.query() {
+                redirect.push('?');
+                redirect.push_str(query);
+            }
+            m.admin_url(&base, &redirect)
         }
-        server.admin_url(&base, &redirect)
-    } else {
-        url
+        _ => url,
     };
     drop(server);
     open::that(target).map_err(|e| e.to_string())
@@ -664,38 +773,60 @@ pub async fn list_chat_models(
 /// on the registry. An empty `code` clears. The plaintext is hashed here
 /// (salted) and never stored.
 #[tauri::command]
-pub fn set_collaborator_access_code(
+pub async fn set_collaborator_access_code(
     workspace_id: Option<String>,
     code: String,
     app: tauri::AppHandle,
-    state: State<AppState>,
+    state: State<'_, AppState>,
 ) -> Result<(), String> {
     let salt = state.settings.lock().unwrap().salt.clone();
-    let code = code.trim();
-    markon_core::workspace::validate_access_code(code)?;
+    let code = code.trim().to_string();
+    markon_core::workspace::validate_access_code(&code)?;
     let hash = if code.is_empty() {
         String::new()
     } else {
-        markon_core::workspace::hash_access_code(&salt, code)
+        // The shared per-install salt makes this digest valid on a server
+        // another process started, so a remote set works without re-hashing.
+        markon_core::workspace::hash_access_code(&salt, &code)
     };
     match workspace_id {
         Some(id) if !id.is_empty() => {
-            // Per-workspace: live update on the shared registry (persists via
-            // the registry's persist hook). No restart needed.
-            if state
-                .server
-                .lock()
-                .unwrap()
-                .registry
-                .set_collaborator_access_code(&id, &hash)
-            {
-                Ok(())
-            } else {
-                Err("workspace not found".into())
-            }
+            // Per-workspace: live update. Embedded mutates the shared registry
+            // (persists via its hook); remote pushes over the control API.
+            let remote = {
+                let backend = state.server.lock().unwrap();
+                match &*backend {
+                    ServerBackend::Embedded(m) => {
+                        return if m.registry.set_collaborator_access_code(&id, &hash) {
+                            Ok(())
+                        } else {
+                            Err("workspace not found".into())
+                        };
+                    }
+                    ServerBackend::Remote(r) => r.clone(),
+                }
+            };
+            // Always send the hash (even the empty string) so clearing works:
+            // `Some("")` reaches the server and resets the code, whereas `None`
+            // would serialize to `{}` and leave the existing code untouched.
+            remote
+                .set_access_code(&id, Some(hash.as_str()))
+                .await
+                .map_err(remote_err)
         }
         _ => {
-            // Server-level: persist + restart so the new AppState carries it.
+            // Server-level code. Embedded persists + restarts so the new
+            // AppState carries it. A remote server has no control API for its
+            // server-level code — that needs the owning process's own restart —
+            // so it's unsupported here (the UI disables the editor in remote
+            // mode; this guards the command path too).
+            if state.server.lock().unwrap().is_remote() {
+                return Err(
+                    "the server-level access code can't be changed while connected to an \
+                     external server; set it on that server, or start a local server"
+                        .into(),
+                );
+            }
             {
                 let mut s = state.settings.lock().unwrap();
                 s.collaborator_access_code_hash = hash;
@@ -704,6 +835,73 @@ pub fn set_collaborator_access_code(
             restart_server_and_broadcast(&app, &state)
         }
     }
+}
+
+/// Re-probe for a running server and, if one is up, (re)attach as a controller
+/// (Remote mode), forwarding this install's persisted directory workspaces. Used
+/// to recover after a remote server was restarted or briefly unreachable. Errors
+/// when no server is found (the frontend then offers "start a local server").
+#[tauri::command]
+pub async fn reconnect(
+    app: tauri::AppHandle,
+    state: State<'_, AppState>,
+) -> Result<serde_json::Value, String> {
+    let Some(remote) = RunningServer::discover() else {
+        return Err("no running markon server found".into());
+    };
+    let to_forward: Vec<(String, WorkspaceFlags, Option<String>)> = {
+        let s = state.settings.lock().unwrap();
+        s.workspaces
+            .iter()
+            .filter(|w| w.single_file.is_none())
+            .map(|w| {
+                (
+                    w.path.clone(),
+                    w.flags,
+                    (!w.collaborator_access_code_hash.is_empty())
+                        .then(|| w.collaborator_access_code_hash.clone()),
+                )
+            })
+            .collect()
+    };
+    for (path, flags, hash) in to_forward {
+        if let Err(e) = remote
+            .add_or_update_workspace(&path, flags, hash.as_deref())
+            .await
+        {
+            tracing::warn!(%path, "failed to forward workspace on reconnect: {e}");
+        }
+    }
+    let port = remote.port();
+    *state.server.lock().unwrap() = ServerBackend::Remote(remote);
+    let _ = app.emit("server-status-changed", server_status_payload(&state));
+    Ok(serde_json::json!({ "mode": "remote", "port": port }))
+}
+
+/// Transition to owning an in-process (Embedded) server, starting one from the
+/// current settings. Used when the user wants their own server after a remote
+/// died (no auto-takeover). Dropping any prior Remote handle does NOT stop the
+/// remote — only Embedded owns a lifecycle.
+#[tauri::command]
+pub fn start_local_server(
+    app: tauri::AppHandle,
+    state: State<AppState>,
+) -> Result<(), String> {
+    // Enforce the single-server invariant at the command, not just the UI: if a
+    // server is live (e.g. a different daemon came up while we were
+    // disconnected), starting our own would clobber the machine lock and orphan
+    // it. Refuse and steer the user to reconnect.
+    if RunningServer::discover().is_some() {
+        return Err("a markon server is already running — use Reconnect instead of starting a second one".into());
+    }
+    let settings = state.settings.lock().unwrap().clone();
+    let config = settings.to_server_config(effective_port(&settings));
+    let persist = AppSettings::persist_hook(state.settings.clone());
+    let mut manager = ServerManager::new();
+    let result = manager.start(config, Some(persist));
+    *state.server.lock().unwrap() = ServerBackend::Embedded(manager);
+    let _ = app.emit("server-status-changed", server_status_payload(&state));
+    result
 }
 
 #[tauri::command]

--- a/crates/gui/src/commands.rs
+++ b/crates/gui/src/commands.rs
@@ -23,8 +23,14 @@ const MARKON_REPO: &str = "kookyleo/markon";
 /// a network change). Mirrored by `get_server_status` for cold reads.
 fn server_status_payload(state: &State<AppState>) -> serde_json::Value {
     let server = state.server.lock().unwrap();
-    let bind_host = state.settings.lock().unwrap().host.clone();
+    let configured_host = state.settings.lock().unwrap().host.clone();
     let is_remote = server.is_remote();
+    let bind_host = match &*server {
+        ServerBackend::Remote(remote) if !remote.bind_host().trim().is_empty() => {
+            remote.bind_host().to_string()
+        }
+        _ => configured_host,
+    };
     // In remote mode this GUI doesn't bind anything, so the local bind-host
     // availability check is meaningless — report available so no stale banner
     // shows. The frontend keys off `mode` to render the connection state.
@@ -53,10 +59,8 @@ fn remote_err(e: ControlError) -> String {
 /// embedded (in-process registry) and remote (control API) list paths so every
 /// field the panel reads stays identical across both modes.
 fn workspace_panel_json(info: WorkspaceInfo, browser_base: &str) -> serde_json::Value {
-    let url = server::build_workspace_url(
-        browser_base,
-        &server::workspace_url_path(&info.id, None),
-    );
+    let url =
+        server::build_workspace_url(browser_base, &server::workspace_url_path(&info.id, None));
     serde_json::json!({
         "id": info.id,
         "path": info.path,
@@ -245,7 +249,7 @@ pub fn save_settings(
     #[cfg(target_os = "windows")]
     sync_shell_context_menu(&settings.language);
 
-    settings.save()?;
+    settings.save_preserving_server_owned_state()?;
     *state.settings.lock().unwrap() = settings;
     restart_server_and_broadcast(&app, &state)
 }
@@ -280,12 +284,21 @@ fn update_tray_language(app: &tauri::AppHandle, language: &str) {
 // to settings.json happens via the persist hook wired at server startup,
 // so CLI (HTTP API) and GUI (Tauri API) paths share a single flow.
 
-fn browser_base_url_for_state(state: &State<AppState>, port: u16) -> String {
+fn browser_base_url_for_state(
+    state: &State<AppState>,
+    port: u16,
+    server_bind_host: Option<&str>,
+    server_advertised_host: Option<&str>,
+) -> String {
     let (bind_host, advertised_host) = {
         let s = state.settings.lock().unwrap();
         (s.host.clone(), s.advertised_host.clone())
     };
-    server::featured_base_url(&bind_host, &advertised_host, port)
+    let bind_host = server_bind_host
+        .filter(|host| !host.trim().is_empty())
+        .unwrap_or(&bind_host);
+    let advertised_host = server_advertised_host.unwrap_or(&advertised_host);
+    server::featured_base_url(bind_host, advertised_host, port)
 }
 
 fn is_example_workspace_path(path: &str) -> bool {
@@ -337,21 +350,24 @@ pub async fn add_workspace(
             ServerBackend::Remote(r) => Dispatch::Remote(r.clone()),
         }
     };
-    let (id, port) = match dispatch {
-        Dispatch::Embedded(id, port) => (id, port),
+    let (id, browser_base) = match dispatch {
+        Dispatch::Embedded(id, port) => (id, browser_base_url_for_state(&state, port, None, None)),
         Dispatch::Remote(remote) => {
             let path_str = canonical.to_string_lossy().to_string();
             let id = remote
-                .add_or_update_workspace(&path_str, flags, None)
+                .add_or_update_workspace(&path_str, flags, true, None, None, None)
                 .await
                 .map_err(remote_err)?;
-            (id, remote.port())
+            let browser_base = browser_base_url_for_state(
+                &state,
+                remote.port(),
+                Some(remote.bind_host()),
+                remote.advertised_host(),
+            );
+            (id, browser_base)
         }
     };
-    let url = server::build_workspace_url(
-        &browser_base_url_for_state(&state, port),
-        &server::workspace_url_path(&id, None),
-    );
+    let url = server::build_workspace_url(&browser_base, &server::workspace_url_path(&id, None));
     Ok(serde_json::json!({ "id": id, "url": url }))
 }
 
@@ -439,7 +455,7 @@ pub async fn remove_workspace(id: String, state: State<'_, AppState>) -> Result<
                 if is_example {
                     let mut settings = state.settings.lock().unwrap();
                     settings.example_workspace_hidden = true;
-                    settings.save()?;
+                    settings.save_preserving_server_owned_state()?;
                 }
                 return Ok(());
             }
@@ -454,10 +470,14 @@ pub async fn remove_workspace(id: String, state: State<'_, AppState>) -> Result<
         .find(|info| info.id == id)
         .is_some_and(|info| is_example_workspace_path(&info.path));
     remote.remove_workspace(&id).await.map_err(remote_err)?;
-    if is_example {
+    let infos = remote.list_workspaces().await.map_err(remote_err)?;
+    {
         let mut settings = state.settings.lock().unwrap();
-        settings.example_workspace_hidden = true;
-        settings.save()?;
+        settings.sync_from_workspace_infos(infos);
+        if is_example {
+            settings.example_workspace_hidden = true;
+            settings.save_preserving_server_owned_state()?;
+        }
     }
     Ok(())
 }
@@ -465,9 +485,7 @@ pub async fn remove_workspace(id: String, state: State<'_, AppState>) -> Result<
 /// List all active workspaces with their IDs and URLs. Works in both modes via
 /// the shared `workspace_panel_json` mapping over `WorkspaceInfo`.
 #[tauri::command]
-pub async fn get_workspaces(
-    state: State<'_, AppState>,
-) -> Result<Vec<serde_json::Value>, String> {
+pub async fn get_workspaces(state: State<'_, AppState>) -> Result<Vec<serde_json::Value>, String> {
     enum Dispatch {
         Embedded(u16, Vec<WorkspaceInfo>),
         Remote(RunningServer, u16),
@@ -479,13 +497,29 @@ pub async fn get_workspaces(
             ServerBackend::Remote(r) => Dispatch::Remote(r.clone(), r.port()),
         }
     };
-    let (port, infos) = match dispatch {
-        Dispatch::Embedded(port, infos) => (port, infos),
+    let (port, infos, server_bind_host, server_advertised_host) = match dispatch {
+        Dispatch::Embedded(port, infos) => (port, infos, None, None),
         Dispatch::Remote(remote, port) => {
-            (port, remote.list_workspaces().await.map_err(remote_err)?)
+            let infos = remote.list_workspaces().await.map_err(remote_err)?;
+            state
+                .settings
+                .lock()
+                .unwrap()
+                .sync_from_workspace_infos(infos.clone());
+            (
+                port,
+                infos,
+                Some(remote.bind_host().to_string()),
+                remote.advertised_host().map(str::to_string),
+            )
         }
     };
-    let browser_base = browser_base_url_for_state(&state, port);
+    let browser_base = browser_base_url_for_state(
+        &state,
+        port,
+        server_bind_host.as_deref(),
+        server_advertised_host.as_deref(),
+    );
     Ok(infos
         .into_iter()
         .map(|info| workspace_panel_json(info, &browser_base))
@@ -495,31 +529,39 @@ pub async fn get_workspaces(
 /// Set (or clear, with an empty string) a workspace's alias. Per-workspace and
 /// live — updates the shared registry (persists via its hook), no restart.
 #[tauri::command]
-pub fn set_alias(
+pub async fn set_alias(
     workspace_id: String,
     alias: String,
-    state: State<AppState>,
+    state: State<'_, AppState>,
 ) -> Result<(), String> {
-    match &*state.server.lock().unwrap() {
-        ServerBackend::Embedded(m) => {
-            if m.registry.set_alias(&workspace_id, alias.trim()) {
-                Ok(())
-            } else {
-                Err("workspace not found".into())
+    let remote = {
+        let backend = state.server.lock().unwrap();
+        match &*backend {
+            ServerBackend::Embedded(m) => {
+                return if m.registry.set_alias(&workspace_id, alias.trim()) {
+                    Ok(())
+                } else {
+                    Err("workspace not found".into())
+                };
             }
+            ServerBackend::Remote(remote) => remote.clone(),
         }
-        // The control API has no alias endpoint, so an alias can't be pushed to
-        // a server another process is running.
-        ServerBackend::Remote(_) => {
-            Err("setting an alias is not supported while connected to an external server".into())
-        }
-    }
+    };
+    remote
+        .set_alias(&workspace_id, alias.trim())
+        .await
+        .map_err(remote_err)
 }
 
 #[tauri::command]
 pub fn open_url(url: String, state: State<AppState>) -> Result<(), String> {
     let server = state.server.lock().unwrap();
-    let base = browser_base_url_for_state(&state, server.port());
+    let (remote_host, remote_advertised_host) = match &*server {
+        ServerBackend::Remote(remote) => (Some(remote.bind_host()), remote.advertised_host()),
+        ServerBackend::Embedded(_) => (None, None),
+    };
+    let base =
+        browser_base_url_for_state(&state, server.port(), remote_host, remote_advertised_host);
     let markon_prefix = format!("{}/", base.trim_end_matches('/'));
     // Only an embedded server can mint a one-time admin bootstrap (its
     // AdminBootstrapStore). For a remote server, bootstrap belongs to the owning
@@ -838,9 +880,10 @@ pub async fn set_collaborator_access_code(
 }
 
 /// Re-probe for a running server and, if one is up, (re)attach as a controller
-/// (Remote mode), forwarding this install's persisted directory workspaces. Used
-/// to recover after a remote server was restarted or briefly unreachable. Errors
-/// when no server is found (the frontend then offers "start a local server").
+/// (Remote mode), forwarding this install's persisted workspaces with their
+/// directory/single-file scopes intact. Used to recover after a remote server
+/// was restarted or briefly unreachable. Errors when no server is found (the
+/// frontend then offers "start a local server").
 #[tauri::command]
 pub async fn reconnect(
     app: tauri::AppHandle,
@@ -849,29 +892,34 @@ pub async fn reconnect(
     let Some(remote) = RunningServer::discover() else {
         return Err("no running markon server found".into());
     };
-    let to_forward: Vec<(String, WorkspaceFlags, Option<String>)> = {
+    // TCP reachability alone is not identity: a stale lock's port may have been
+    // reused by an unrelated process. Authenticate one management request
+    // before switching the GUI into Remote mode.
+    remote.list_workspaces().await.map_err(remote_err)?;
+    let to_forward = {
         let s = state.settings.lock().unwrap();
-        s.workspaces
-            .iter()
-            .filter(|w| w.single_file.is_none())
-            .map(|w| {
-                (
-                    w.path.clone(),
-                    w.flags,
-                    (!w.collaborator_access_code_hash.is_empty())
-                        .then(|| w.collaborator_access_code_hash.clone()),
-                )
-            })
-            .collect()
+        s.workspaces.clone()
     };
-    for (path, flags, hash) in to_forward {
-        if let Err(e) = remote
-            .add_or_update_workspace(&path, flags, hash.as_deref())
+    for workspace in to_forward {
+        remote
+            .add_or_update_workspace(
+                &workspace.path,
+                workspace.flags,
+                true,
+                workspace.single_file.as_deref(),
+                (!workspace.collaborator_access_code_hash.is_empty())
+                    .then_some(workspace.collaborator_access_code_hash.as_str()),
+                Some(&workspace.alias),
+            )
             .await
-        {
-            tracing::warn!(%path, "failed to forward workspace on reconnect: {e}");
-        }
+            .map_err(remote_err)?;
     }
+    let infos = remote.list_workspaces().await.map_err(remote_err)?;
+    state
+        .settings
+        .lock()
+        .unwrap()
+        .sync_from_workspace_infos(infos);
     let port = remote.port();
     *state.server.lock().unwrap() = ServerBackend::Remote(remote);
     let _ = app.emit("server-status-changed", server_status_payload(&state));
@@ -883,16 +931,16 @@ pub async fn reconnect(
 /// died (no auto-takeover). Dropping any prior Remote handle does NOT stop the
 /// remote — only Embedded owns a lifecycle.
 #[tauri::command]
-pub fn start_local_server(
-    app: tauri::AppHandle,
-    state: State<AppState>,
-) -> Result<(), String> {
+pub fn start_local_server(app: tauri::AppHandle, state: State<AppState>) -> Result<(), String> {
     // Enforce the single-server invariant at the command, not just the UI: if a
     // server is live (e.g. a different daemon came up while we were
     // disconnected), starting our own would clobber the machine lock and orphan
     // it. Refuse and steer the user to reconnect.
     if RunningServer::discover().is_some() {
-        return Err("a markon server is already running — use Reconnect instead of starting a second one".into());
+        return Err(
+            "a markon server is already running — use Reconnect instead of starting a second one"
+                .into(),
+        );
     }
     let settings = state.settings.lock().unwrap().clone();
     let config = settings.to_server_config(effective_port(&settings));
@@ -913,7 +961,7 @@ pub fn set_tray_resident(
     state.tray_resident.store(value, Ordering::Relaxed);
     let mut settings = state.settings.lock().unwrap();
     settings.tray_resident = value;
-    settings.save()?;
+    settings.save_preserving_server_owned_state()?;
     drop(settings);
     if let Some(tray) = app.tray_by_id("main") {
         tray.set_visible(value).map_err(|e| e.to_string())?;

--- a/crates/gui/src/main.rs
+++ b/crates/gui/src/main.rs
@@ -8,7 +8,8 @@ mod server_manager;
 
 use markon_core::settings::{AppSettings, WorkspaceSettings};
 use markon_core::workspace::{expand_and_canonicalize, WorkspaceFlags};
-use server_manager::ServerManager;
+use markon_core::control::RunningServer;
+use server_manager::{ServerBackend, ServerManager};
 use std::path::{Path, PathBuf};
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
@@ -92,7 +93,9 @@ fn install_exe_window_icon(window: &tauri::WebviewWindow) {
 
 pub struct AppState {
     pub settings: Arc<Mutex<AppSettings>>,
-    pub server: Mutex<ServerManager>,
+    /// Either an in-process server we own, or a controller handle attached to a
+    /// server another process already had running. See `ServerBackend`.
+    pub server: Mutex<ServerBackend>,
     /// UNIX-millis of the most recent file/folder open intent (RunEvent::Opened).
     /// A paired Reopen Apple Event arrives right after Opened; we suppress that
     /// one so an "Open With" doesn't *also* adopt the front Finder folder. Stored
@@ -333,50 +336,83 @@ fn handle_open_path(app: &tauri::AppHandle, path: &Path) {
     };
 
     let state = app.state::<AppState>();
-    let server = state.server.lock().unwrap();
 
-    if !server.is_running() {
-        tracing::warn!("server not running, cannot open path");
-        return;
-    }
-
-    let (flags, browser_base) = {
+    // Single-file workspaces follow the user's defaults for every flag. Search
+    // is safe here: the embedded registry builds a file-scoped index (only the
+    // pinned file, no parent WalkDir), so there's no sibling leakage.
+    let flags = {
         let settings = state.settings.lock().unwrap();
-        // Single-file workspaces follow the user's defaults for every flag.
-        // Search is safe here: the registry builds a file-scoped index (only
-        // the pinned file, no parent WalkDir), so there's no sibling leakage.
-        (
-            markon_core::workspace::WorkspaceFlags {
-                enable_search: settings.default_search,
-                enable_viewed: settings.default_viewed,
-                enable_edit: settings.default_edit,
-                enable_live: settings.default_live,
-                enable_chat: settings.default_chat,
-                shared_annotation: settings.default_shared_annotation,
-            },
+        markon_core::workspace::WorkspaceFlags {
+            enable_search: settings.default_search,
+            enable_viewed: settings.default_viewed,
+            enable_edit: settings.default_edit,
+            enable_live: settings.default_live,
+            enable_chat: settings.default_chat,
+            shared_annotation: settings.default_shared_annotation,
+        }
+    };
+
+    // Resolve what to open. Embedded builds an admin-bootstrapped URL in place.
+    // Remote forwards over HTTP: its add API has no single_file parameter, so
+    // the parent directory becomes the workspace and we still deep-link to the
+    // file — no admin session, since bootstrap belongs to the owning process.
+    enum OpenPlan {
+        Ready(String),
+        Remote(RunningServer, String, String),
+    }
+    let plan = {
+        let backend = state.server.lock().unwrap();
+        if !backend.is_running() {
+            tracing::warn!("server not running, cannot open path");
+            return;
+        }
+        let browser_base = {
+            let settings = state.settings.lock().unwrap();
             markon_core::server::featured_base_url(
                 &settings.host,
                 &settings.advertised_host,
-                server.port(),
-            ),
-        )
+                backend.port(),
+            )
+        };
+        match &*backend {
+            ServerBackend::Embedded(m) => {
+                // `registry.add` is idempotent on (path, single_file) and fires
+                // the persist hook, mirroring the entry into AppSettings.
+                let id = m.registry.add(markon_core::workspace::WorkspaceConfig {
+                    path: ws_root,
+                    flags,
+                    single_file,
+                    collaborator_access_code_hash: String::new(),
+                    alias: String::new(),
+                });
+                let workspace_path =
+                    markon_core::server::workspace_url_path(&id, rel_path.as_deref());
+                OpenPlan::Ready(m.admin_url(&browser_base, &workspace_path))
+            }
+            ServerBackend::Remote(r) => {
+                OpenPlan::Remote(r.clone(), ws_root.to_string_lossy().to_string(), browser_base)
+            }
+        }
     };
 
-    // `registry.add` is idempotent on (path, single_file) and triggers the
-    // persist hook, which mirrors both directory and temporary single-file
-    // workspaces into AppSettings.
-    let id = server
-        .registry
-        .add(markon_core::workspace::WorkspaceConfig {
-            path: ws_root,
-            flags,
-            single_file,
-            collaborator_access_code_hash: String::new(),
-            alias: String::new(),
-        });
-    let workspace_path = markon_core::server::workspace_url_path(&id, rel_path.as_deref());
-    let url = server.admin_url(&browser_base, &workspace_path);
-    drop(server);
+    let url = match plan {
+        OpenPlan::Ready(url) => url,
+        OpenPlan::Remote(remote, path_str, browser_base) => {
+            match tauri::async_runtime::block_on(remote.add_or_update_workspace(
+                &path_str, flags, None,
+            )) {
+                Ok(id) => {
+                    let workspace_path =
+                        markon_core::server::workspace_url_path(&id, rel_path.as_deref());
+                    markon_core::server::build_workspace_url(&browser_base, &workspace_path)
+                }
+                Err(e) => {
+                    tracing::warn!(path = %path_str, "failed to open path on remote server: {e}");
+                    return;
+                }
+            }
+        }
+    };
 
     let _ = open::that(url);
 
@@ -752,20 +788,64 @@ fn main() {
             #[cfg(target_os = "windows")]
             commands::sync_shell_context_menu(&language_init);
 
+            // Snapshot the persisted workspaces before `settings` is moved into
+            // the shared Arc — needed to forward them if we attach to a remote.
+            // Single-file/ephemeral entries are skipped: the remote add API has
+            // no single_file parameter, and they're pruned at startup anyway.
+            let workspaces_to_forward: Vec<(String, WorkspaceFlags, Option<String>)> = settings
+                .workspaces
+                .iter()
+                .filter(|w| w.single_file.is_none())
+                .map(|w| {
+                    (
+                        w.path.clone(),
+                        w.flags,
+                        (!w.collaborator_access_code_hash.is_empty())
+                            .then(|| w.collaborator_access_code_hash.clone()),
+                    )
+                })
+                .collect();
+
             let settings_arc = Arc::new(Mutex::new(settings));
             let persist_hook = AppSettings::persist_hook(settings_arc.clone());
+
+            // One-server-per-machine: if a server is already up, attach to it as
+            // a controller (Remote) and forward our workspaces instead of
+            // binding a competing server. Otherwise own an Embedded one.
+            let backend = match RunningServer::discover() {
+                Some(remote) => {
+                    tracing::info!(
+                        port = remote.port(),
+                        "attaching to already-running markon server (remote mode)"
+                    );
+                    let remote_for_forward = remote.clone();
+                    tauri::async_runtime::block_on(async move {
+                        for (path, flags, hash) in workspaces_to_forward {
+                            if let Err(e) = remote_for_forward
+                                .add_or_update_workspace(&path, flags, hash.as_deref())
+                                .await
+                            {
+                                tracing::warn!(%path, "failed to forward workspace to remote: {e}");
+                            }
+                        }
+                    });
+                    ServerBackend::Remote(remote)
+                }
+                None => {
+                    let mut manager = ServerManager::new();
+                    if let Err(e) = manager.start(config, Some(persist_hook)) {
+                        tracing::error!("server failed to start: {e}");
+                    }
+                    ServerBackend::Embedded(manager)
+                }
+            };
             let state = AppState {
                 settings: settings_arc,
-                server: Mutex::new(ServerManager::new()),
+                server: Mutex::new(backend),
                 last_file_open_ms: AtomicU64::new(0),
                 tray_resident: Arc::new(AtomicBool::new(tray_resident_init)),
                 pending_new_workspace: AtomicBool::new(false),
             };
-            let mut server = state.server.lock().unwrap();
-            if let Err(e) = server.start(config, Some(persist_hook)) {
-                tracing::error!("server failed to start: {e}");
-            }
-            drop(server);
             app.manage(state);
 
             #[cfg(target_os = "macos")]
@@ -899,6 +979,8 @@ fn main() {
             commands::update_workspace,
             commands::remove_workspace,
             commands::get_workspaces,
+            commands::reconnect,
+            commands::start_local_server,
             commands::open_url,
             commands::get_bind_hosts,
             commands::get_server_status,

--- a/crates/gui/src/main.rs
+++ b/crates/gui/src/main.rs
@@ -6,9 +6,9 @@ mod reopen_origin;
 mod server_manager;
 // settings moved to markon_core::settings
 
+use markon_core::control::RunningServer;
 use markon_core::settings::{AppSettings, WorkspaceSettings};
 use markon_core::workspace::{expand_and_canonicalize, WorkspaceFlags};
-use markon_core::control::RunningServer;
 use server_manager::{ServerBackend, ServerManager};
 use std::path::{Path, PathBuf};
 use std::sync::{
@@ -353,12 +353,12 @@ fn handle_open_path(app: &tauri::AppHandle, path: &Path) {
     };
 
     // Resolve what to open. Embedded builds an admin-bootstrapped URL in place.
-    // Remote forwards over HTTP: its add API has no single_file parameter, so
-    // the parent directory becomes the workspace and we still deep-link to the
-    // file — no admin session, since bootstrap belongs to the owning process.
+    // Remote forwards the same root + single-file scope over the management API,
+    // preserving the filesystem capability boundary. It opens without an admin
+    // session because bootstrap ownership stays with the server process.
     enum OpenPlan {
         Ready(String),
-        Remote(RunningServer, String, String),
+        Remote(RunningServer, String, Option<String>, String),
     }
     let plan = {
         let backend = state.server.lock().unwrap();
@@ -366,22 +366,23 @@ fn handle_open_path(app: &tauri::AppHandle, path: &Path) {
             tracing::warn!("server not running, cannot open path");
             return;
         }
-        let browser_base = {
+        let (configured_host, advertised_host) = {
             let settings = state.settings.lock().unwrap();
-            markon_core::server::featured_base_url(
-                &settings.host,
-                &settings.advertised_host,
-                backend.port(),
-            )
+            (settings.host.clone(), settings.advertised_host.clone())
         };
         match &*backend {
             ServerBackend::Embedded(m) => {
+                let browser_base = markon_core::server::featured_base_url(
+                    &configured_host,
+                    &advertised_host,
+                    m.port(),
+                );
                 // `registry.add` is idempotent on (path, single_file) and fires
                 // the persist hook, mirroring the entry into AppSettings.
                 let id = m.registry.add(markon_core::workspace::WorkspaceConfig {
                     path: ws_root,
                     flags,
-                    single_file,
+                    single_file: single_file.clone(),
                     collaborator_access_code_hash: String::new(),
                     alias: String::new(),
                 });
@@ -390,16 +391,37 @@ fn handle_open_path(app: &tauri::AppHandle, path: &Path) {
                 OpenPlan::Ready(m.admin_url(&browser_base, &workspace_path))
             }
             ServerBackend::Remote(r) => {
-                OpenPlan::Remote(r.clone(), ws_root.to_string_lossy().to_string(), browser_base)
+                let bind_host = if r.bind_host().trim().is_empty() {
+                    &configured_host
+                } else {
+                    r.bind_host()
+                };
+                let active_advertised_host = r.advertised_host().unwrap_or(&advertised_host);
+                let browser_base = markon_core::server::featured_base_url(
+                    bind_host,
+                    active_advertised_host,
+                    r.port(),
+                );
+                OpenPlan::Remote(
+                    r.clone(),
+                    ws_root.to_string_lossy().to_string(),
+                    single_file.clone(),
+                    browser_base,
+                )
             }
         }
     };
 
     let url = match plan {
         OpenPlan::Ready(url) => url,
-        OpenPlan::Remote(remote, path_str, browser_base) => {
+        OpenPlan::Remote(remote, path_str, single_file, browser_base) => {
             match tauri::async_runtime::block_on(remote.add_or_update_workspace(
-                &path_str, flags, None,
+                &path_str,
+                flags,
+                true,
+                single_file.as_deref(),
+                None,
+                None,
             )) {
                 Ok(id) => {
                     let workspace_path =
@@ -499,7 +521,7 @@ fn persist_settings_window_size(app: &tauri::AppHandle, window: &tauri::WebviewW
     let mut settings = state.settings.lock().unwrap();
     settings.window_width = Some(logical.width);
     settings.window_height = Some(logical.height);
-    settings.save().ok();
+    settings.save_preserving_server_owned_state().ok();
 }
 
 fn configure_settings_window(app: &tauri::AppHandle, window: &tauri::WebviewWindow) {
@@ -790,21 +812,9 @@ fn main() {
 
             // Snapshot the persisted workspaces before `settings` is moved into
             // the shared Arc — needed to forward them if we attach to a remote.
-            // Single-file/ephemeral entries are skipped: the remote add API has
-            // no single_file parameter, and they're pruned at startup anyway.
-            let workspaces_to_forward: Vec<(String, WorkspaceFlags, Option<String>)> = settings
-                .workspaces
-                .iter()
-                .filter(|w| w.single_file.is_none())
-                .map(|w| {
-                    (
-                        w.path.clone(),
-                        w.flags,
-                        (!w.collaborator_access_code_hash.is_empty())
-                            .then(|| w.collaborator_access_code_hash.clone()),
-                    )
-                })
-                .collect();
+            // The management API carries `single_file` explicitly, preserving
+            // the same narrow filesystem capability as the embedded registry.
+            let workspaces_to_forward = settings.workspaces.clone();
 
             let settings_arc = Arc::new(Mutex::new(settings));
             let persist_hook = AppSettings::persist_hook(settings_arc.clone());
@@ -820,12 +830,20 @@ fn main() {
                     );
                     let remote_for_forward = remote.clone();
                     tauri::async_runtime::block_on(async move {
-                        for (path, flags, hash) in workspaces_to_forward {
+                        for workspace in workspaces_to_forward {
                             if let Err(e) = remote_for_forward
-                                .add_or_update_workspace(&path, flags, hash.as_deref())
+                                .add_or_update_workspace(
+                                    &workspace.path,
+                                    workspace.flags,
+                                    true,
+                                    workspace.single_file.as_deref(),
+                                    (!workspace.collaborator_access_code_hash.is_empty())
+                                        .then_some(workspace.collaborator_access_code_hash.as_str()),
+                                    Some(&workspace.alias),
+                                )
                                 .await
                             {
-                                tracing::warn!(%path, "failed to forward workspace to remote: {e}");
+                                tracing::warn!(path = %workspace.path, "failed to forward workspace to remote: {e}");
                             }
                         }
                     });

--- a/crates/gui/src/server_manager.rs
+++ b/crates/gui/src/server_manager.rs
@@ -1,7 +1,72 @@
 use markon_core::admin_auth::AdminBootstrapStore;
+use markon_core::control::RunningServer;
 use markon_core::server::{self, ServerConfig};
 use markon_core::workspace::{PersistHook, WorkspaceRegistry};
 use std::sync::Arc;
+
+/// Where this GUI's workspace commands are actually served from.
+///
+/// The machine invariant is "one markon server". On boot the GUI probes for an
+/// already-running server (see `RunningServer::discover`): if one is up it
+/// attaches as a *controller* (`Remote`) and drives that server's registry over
+/// its loopback management API instead of binding a second server; otherwise it
+/// owns an in-process `Embedded` server. Every registry-touching command
+/// dispatches on this enum so both modes behave identically to the frontend.
+pub enum ServerBackend {
+    Embedded(ServerManager),
+    /// Attached to a server another process started. We do NOT own its
+    /// lifecycle — dropping this (app quit) must not stop that server, which is
+    /// why `RunningServer` has no `Drop` that shuts anything down.
+    Remote(RunningServer),
+}
+
+impl ServerBackend {
+    /// Port the browser should hit — the embedded server's bound port, or the
+    /// remote server's loopback port.
+    pub fn port(&self) -> u16 {
+        match self {
+            ServerBackend::Embedded(m) => m.port(),
+            ServerBackend::Remote(r) => r.port(),
+        }
+    }
+
+    /// Whether a server is reachable. A remote is assumed live (discovery
+    /// TCP-probed it; a dead remote surfaces as a per-command error instead).
+    pub fn is_running(&self) -> bool {
+        match self {
+            ServerBackend::Embedded(m) => m.is_running(),
+            ServerBackend::Remote(_) => true,
+        }
+    }
+
+    pub fn last_error(&self) -> Option<String> {
+        match self {
+            ServerBackend::Embedded(m) => m.last_error(),
+            ServerBackend::Remote(_) => None,
+        }
+    }
+
+    pub fn is_remote(&self) -> bool {
+        matches!(self, ServerBackend::Remote(_))
+    }
+
+    /// Clone the remote handle so an async command can drop the (non-Send) lock
+    /// guard before awaiting the HTTP call. `None` in embedded mode.
+    pub fn remote(&self) -> Option<RunningServer> {
+        match self {
+            ServerBackend::Remote(r) => Some(r.clone()),
+            ServerBackend::Embedded(_) => None,
+        }
+    }
+
+    /// `"remote"` when attached to another process's server, else `"embedded"`.
+    pub fn mode(&self) -> &'static str {
+        match self {
+            ServerBackend::Embedded(_) => "embedded",
+            ServerBackend::Remote(_) => "remote",
+        }
+    }
+}
 
 pub struct ServerManager {
     abort_tx: Option<tokio::sync::oneshot::Sender<()>>,

--- a/crates/gui/src/server_manager.rs
+++ b/crates/gui/src/server_manager.rs
@@ -104,6 +104,20 @@ impl ServerManager {
         self.stop();
         self.last_error = None;
 
+        // Re-check at the ownership boundary, not only during app boot. A
+        // daemon may have appeared between discovery and this start (or while
+        // an embedded server was being restarted); binding another port would
+        // violate the one-server invariant and replace its discovery lock.
+        if let Some(remote) = RunningServer::discover() {
+            let message = format!(
+                "a markon server is already running on port {}; reconnect instead",
+                remote.port()
+            );
+            self.last_error = Some(message.clone());
+            self.port = 0;
+            return Err(message);
+        }
+
         // Use the salt the caller put into ServerConfig (GUI: per-install random
         // salt from AppSettings). Fall back to a port-derived constant only for
         // callers that didn't set one — preserves the original CLI behavior.

--- a/crates/gui/ui/index.html
+++ b/crates/gui/ui/index.html
@@ -1038,11 +1038,11 @@
                server or attaches to one another process already started.
                Populated by applyServerMode() from get_server_status.mode. -->
           <div id="server-mode-row" class="pref-row" style="display:none">
-            <span class="pref-label">Server</span>
+            <span class="pref-label" data-i18n="server.mode.label"></span>
             <div class="pref-control" style="font-size:12px;line-height:1.5;max-width:400px">
               <span id="server-mode-text"></span>
-              <button type="button" class="btn" id="server-reconnect-btn" style="margin-left:8px;display:none">Reconnect</button>
-              <button type="button" class="btn" id="server-start-local-btn" style="margin-left:8px;display:none">Start local server</button>
+              <button type="button" class="btn" id="server-reconnect-btn" data-i18n="server.action.reconnect" style="margin-left:8px;display:none"></button>
+              <button type="button" class="btn" id="server-start-local-btn" data-i18n="server.action.start_local" style="margin-left:8px;display:none"></button>
             </div>
           </div>
           <div class="pref-row">
@@ -1511,6 +1511,7 @@
   // Server-level access-code editing is only possible in embedded mode; the
   // control API can't change a remote server's own server-level code.
   let globalServerMode = 'embedded';
+  let globalServerPort = null;
 
   // ── Tab navigation ──────────────────────────────────────────────────────
   function activateTab(name) {
@@ -1877,8 +1878,11 @@
     // runs — there's no control API to change it — so show a note instead of an
     // editor. Per-workspace codes still work (each card has its own editor).
     if (globalServerMode !== 'embedded') {
-      collaboratorWrap.innerHTML =
-        `<span style="font-size:12px;color:var(--text-dim,#888)">Unavailable while connected to an external server</span>`;
+      collaboratorWrap.innerHTML = '';
+      const note = document.createElement('span');
+      note.style.cssText = 'font-size:12px;color:var(--text-2)';
+      note.textContent = T('server.global_code.remote_unavailable');
+      collaboratorWrap.appendChild(note);
       return;
     }
     collaboratorWrap.innerHTML = accessCodeEditorHTML();
@@ -2625,6 +2629,7 @@
     if (document.getElementById('webstyles-list')?.children.length) {
       renderWebStyles();
     }
+    applyServerMode(globalServerMode, globalServerPort);
   }
 
   // Populate language dropdowns from i18n meta.
@@ -2797,14 +2802,18 @@
   function applyServerMode(mode, port) {
     const prev = globalServerMode;
     globalServerMode = mode;
+    globalServerPort = port ?? globalServerPort;
     const row  = document.getElementById('server-mode-row');
     const text = document.getElementById('server-mode-text');
     const reconnectBtn  = document.getElementById('server-reconnect-btn');
     const startLocalBtn = document.getElementById('server-start-local-btn');
     if (!row || !text) return;
     row.style.display = '';
+    const portText = globalServerPort
+      ? ` (${T('server.mode.port').replace('{port}', String(globalServerPort))})`
+      : '';
     if (mode === 'remote') {
-      text.textContent = `Connected to a running markon${port ? ` (port ${port})` : ''}`;
+      text.textContent = `${T('server.mode.remote')}${portText}`;
       text.style.color = '';
       reconnectBtn.style.display  = '';
       // Never offer "start local server" while the remote is still alive:
@@ -2812,12 +2821,12 @@
       // Only the 'disconnected' state may start a local server.
       startLocalBtn.style.display = 'none';
     } else if (mode === 'disconnected') {
-      text.textContent = 'Lost connection to the running markon';
-      text.style.color = '#d93025';
+      text.textContent = T('server.mode.disconnected');
+      text.style.color = 'var(--danger)';
       reconnectBtn.style.display  = '';
       startLocalBtn.style.display = '';
     } else {
-      text.textContent = `Running own server${port ? ` (port ${port})` : ''}`;
+      text.textContent = `${T('server.mode.embedded')}${portText}`;
       text.style.color = '';
       reconnectBtn.style.display  = 'none';
       startLocalBtn.style.display = 'none';

--- a/crates/gui/ui/index.html
+++ b/crates/gui/ui/index.html
@@ -1034,6 +1034,17 @@
             <span class="pref-label"></span>
             <div class="pref-control" style="color:#d93025;font-size:12px;line-height:1.4;max-width:380px"></div>
           </div>
+          <!-- One-server-per-machine: this GUI either runs its own embedded
+               server or attaches to one another process already started.
+               Populated by applyServerMode() from get_server_status.mode. -->
+          <div id="server-mode-row" class="pref-row" style="display:none">
+            <span class="pref-label">Server</span>
+            <div class="pref-control" style="font-size:12px;line-height:1.5;max-width:400px">
+              <span id="server-mode-text"></span>
+              <button type="button" class="btn" id="server-reconnect-btn" style="margin-left:8px;display:none">Reconnect</button>
+              <button type="button" class="btn" id="server-start-local-btn" style="margin-left:8px;display:none">Start local server</button>
+            </div>
+          </div>
           <div class="pref-row">
             <span class="pref-label">
               <span data-i18n="pref.collaborator_access_code"></span><span class="pref-info" data-i18n-title="pref.collaborator_access_code.hint" tabindex="0">&#9432;</span>
@@ -1495,6 +1506,12 @@
   // draws a fixed CODE_SET_DOTS marker for any set code.
   let globalCollaboratorCodeLen = 0;
 
+  // Backend mode: 'embedded' (we own the server), 'remote' (attached to a
+  // server another process started), or 'disconnected' (a remote call failed).
+  // Server-level access-code editing is only possible in embedded mode; the
+  // control API can't change a remote server's own server-level code.
+  let globalServerMode = 'embedded';
+
   // ── Tab navigation ──────────────────────────────────────────────────────
   function activateTab(name) {
     const item = document.querySelector(`.nav-item[data-tab="${name}"]`);
@@ -1856,6 +1873,14 @@
     // Don't tear down a widget mid-edit (e.g. language switched while typing);
     // labels catch up on the next rebuild.
     if (collaboratorWrap.querySelector('.ac-editor.editing')) return;
+    // In remote mode the server-level code lives on the server another process
+    // runs — there's no control API to change it — so show a note instead of an
+    // editor. Per-workspace codes still work (each card has its own editor).
+    if (globalServerMode !== 'embedded') {
+      collaboratorWrap.innerHTML =
+        `<span style="font-size:12px;color:var(--text-dim,#888)">Unavailable while connected to an external server</span>`;
+      return;
+    }
     collaboratorWrap.innerHTML = accessCodeEditorHTML();
     const collaboratorCtl = wireAccessCode(collaboratorWrap.querySelector('.ac-editor'), {
       len: globalCollaboratorCodeLen,
@@ -2050,7 +2075,17 @@
 
   // ── Workspace list ──────────────────────────────────────────────────────
   async function refreshWorkspaces() {
-    const all = await invoke('get_workspaces');
+    let all;
+    try {
+      all = await invoke('get_workspaces');
+    } catch (e) {
+      // A remote server going away surfaces here — show the recovery banner
+      // (reconnect / start-local) rather than leaving a stale list.
+      if (String(e).includes('remote-server-error')) {
+        applyServerMode('disconnected');
+      }
+      return;
+    }
     // Single-file (Open-With) workspaces ARE listed now — surfaced as dashed
     // "single file" cards so they can be configured/shared like any workspace.
     // They stay transient (not persisted): they vanish when the app exits.
@@ -2753,9 +2788,67 @@
     if (typeof status?.host_available === 'boolean') {
       updateBindWarning(status.host, status.host_available);
     }
+    if (status?.mode) applyServerMode(status.mode, status.port);
+  }
+
+  // Reflect the backend mode (embedded / remote / disconnected) in the Server
+  // section: a status line, the reconnect / start-local buttons, and whether
+  // the server-level access-code editor is available.
+  function applyServerMode(mode, port) {
+    const prev = globalServerMode;
+    globalServerMode = mode;
+    const row  = document.getElementById('server-mode-row');
+    const text = document.getElementById('server-mode-text');
+    const reconnectBtn  = document.getElementById('server-reconnect-btn');
+    const startLocalBtn = document.getElementById('server-start-local-btn');
+    if (!row || !text) return;
+    row.style.display = '';
+    if (mode === 'remote') {
+      text.textContent = `Connected to a running markon${port ? ` (port ${port})` : ''}`;
+      text.style.color = '';
+      reconnectBtn.style.display  = '';
+      // Never offer "start local server" while the remote is still alive:
+      // a second server would clobber the machine lock and orphan the remote.
+      // Only the 'disconnected' state may start a local server.
+      startLocalBtn.style.display = 'none';
+    } else if (mode === 'disconnected') {
+      text.textContent = 'Lost connection to the running markon';
+      text.style.color = '#d93025';
+      reconnectBtn.style.display  = '';
+      startLocalBtn.style.display = '';
+    } else {
+      text.textContent = `Running own server${port ? ` (port ${port})` : ''}`;
+      text.style.color = '';
+      reconnectBtn.style.display  = 'none';
+      startLocalBtn.style.display = 'none';
+    }
+    // The global access-code editor's availability depends on the mode — rebuild
+    // it when the mode actually changed (and no edit is in progress).
+    if (prev !== mode) renderGlobalAccessCode();
+  }
+
+  async function doReconnect() {
+    try {
+      const res = await invoke('reconnect');
+      applyServerMode(res?.mode || 'remote', res?.port);
+      await refreshWorkspaces();
+    } catch (e) {
+      toast(String(e), 'err');
+    }
+  }
+  async function doStartLocalServer() {
+    try {
+      await invoke('start_local_server');
+      await refreshServerStatus();
+      await refreshWorkspaces();
+    } catch (e) {
+      toast(String(e), 'err');
+    }
   }
 
   function setupBindHostListeners() {
+    document.getElementById('server-reconnect-btn')?.addEventListener('click', doReconnect);
+    document.getElementById('server-start-local-btn')?.addEventListener('click', doStartLocalServer);
     const ev = window.__TAURI__?.event;
     if (!ev?.listen) return;
     // Native File ▸ New Workspace (⌘N). The accelerator is registered on the
@@ -2781,6 +2874,7 @@
       if (typeof payload.host_available === 'boolean') {
         updateBindWarning(payload.host, payload.host_available);
       }
+      if (payload.mode) applyServerMode(payload.mode, payload.port);
     });
   }
 


### PR DESCRIPTION
Implements #55: GUI and CLI are controllers for one shared Markon service. The GUI now attaches to an already-running daemon instead of binding a second server and replacing the machine discovery lock.

## Behavior

- On boot, the GUI discovers a live `ServerLock` and attaches as `ServerBackend::Remote`; otherwise it starts and owns `ServerBackend::Embedded`.
- Every workspace command dispatches through the active backend. Quitting the GUI never shuts down a remote server.
- A disconnected remote exposes Reconnect / Start local recovery. Starting local re-checks discovery and refuses while another server is live.
- `ServerLock` records the active bind and advertised hosts, so controller URLs match CLI overrides and the server's actual allowlist.
- Lock cleanup is ownership-aware: an older process cannot delete a newer server's discovery record.

## Filesystem and management boundaries

- `markon_core::control::RunningServer` is the shared loopback management client used by CLI and GUI, with bounded connect/request timeouts.
- Management registration carries `single_file` explicitly. Remote Open-With therefore retains the same `WorkspaceFs::SingleFile` capability as embedded mode; it never widens a file to its parent directory.
- Single-file names are validated as exactly one relative component, and tests prove sibling files remain denied.
- Remote alias updates are supported through a token-gated management endpoint.
- Existing CLI registration preserves configured feature flags; GUI registration explicitly refreshes them to match embedded `WorkspaceRegistry::add` behavior.

## Persistence

- `settings.json` writes are serialized across GUI and daemon with a cross-platform sidecar file lock.
- Registry persistence starts from the newest settings snapshot and overlays only registry-owned workspace state.
- GUI preference saves preserve workspace state, the global collaborator-code hash, and the immutable salt.
- This prevents either process from rolling back the other's fields while preserving workspace IDs across restarts/upgrades.

## UI

- Remote/embedded/disconnected state and recovery actions are translated in English, Simplified Chinese, and Japanese.
- Server-level access-code editing remains unavailable while attached because changing the live server-level gate requires the owning process to restart; per-workspace codes remain fully supported.

## Verification

- `cargo build --workspace --all-features`
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Rust tests: 341 passed (305 core unit tests plus integration/workspace tests)
- TypeScript/Vitest: 42 files, 462 tests passed
- Graphviz static-link policy passed
- GUI inline module parsed successfully with esbuild

New regression coverage includes single-file management scope, sibling denial, control-client payloads, explicit existing-flag policy, active host propagation, and GUI/daemon settings merge behavior.

Closes #55
