### PR TITLE
feat: interactive TUI for `markon ls`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,8 +1085,11 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags 2.13.0",
  "crossterm_winapi",
+ "mio 1.2.1",
  "parking_lot",
  "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
@@ -3633,6 +3636,7 @@ name = "markon"
 version = "0.15.14"
 dependencies = [
  "clap",
+ "crossterm",
  "dialoguer",
  "dunce",
  "markon-core",
@@ -3893,6 +3897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -5969,6 +5974,27 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 1.2.1",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3645,6 +3645,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/main.rs"
 markon-core.workspace = true
 clap = { version = "4.6.1", features = ["derive"] }
 crossterm = "0.28"
+unicode-width = "0.2"
 dialoguer = "0.11"
 tokio = { version = "1.52.1", features = ["full"] }
 serde_json = "1.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,6 +18,7 @@ path = "src/main.rs"
 [dependencies]
 markon-core.workspace = true
 clap = { version = "4.6.1", features = ["derive"] }
+crossterm = "0.28"
 dialoguer = "0.11"
 tokio = { version = "1.52.1", features = ["full"] }
 serde_json = "1.0"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -13,6 +13,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 mod feedback;
+mod tui;
 
 fn get_available_hosts() -> Vec<(String, String)> {
     available_bind_hosts()
@@ -104,9 +105,10 @@ enum Commands {
     },
     /// List all active workspaces in the running server.
     Ls {
-        /// Output format.
-        #[arg(long, value_enum, default_value_t = WorkspaceListFormat::Cards)]
-        format: WorkspaceListFormat,
+        /// Output format. Omit on an interactive terminal to launch the
+        /// interactive browser; omit when piped/redirected for static cards.
+        #[arg(long, value_enum)]
+        format: Option<WorkspaceListFormat>,
     },
     /// Remove a workspace from the running server by ID or index.
     Detach {
@@ -237,6 +239,25 @@ impl CliColors {
     }
 }
 
+/// Whether an interactive full-screen TUI should launch for a bare `markon ls`.
+///
+/// Requires both stdin and stdout to be real terminals AND a usable `TERM`
+/// (set and not `dumb`), mirroring [`CliColors::detect`]'s capability gate — a
+/// whole-screen alternate-screen app is far more invasive than color, so a
+/// dumb/limited terminal (or `TERM` unset) falls back to static cards instead
+/// of emitting alternate-screen / cursor-hide escapes as literal garbage.
+/// `MARKON_NO_TUI` is an explicit escape hatch for PTY environments that
+/// report a terminal but should stay non-interactive.
+fn tui_enabled() -> bool {
+    if std::env::var_os("MARKON_NO_TUI").is_some() {
+        return false;
+    }
+    let term_ok = std::env::var("TERM")
+        .map(|term| term != "dumb")
+        .unwrap_or(false);
+    term_ok && std::io::stdin().is_terminal() && std::io::stdout().is_terminal()
+}
+
 fn display_workspace_path(path: &Path) -> String {
     if let Some(home) = std::env::var_os("HOME") {
         let home = std::path::PathBuf::from(home);
@@ -251,31 +272,60 @@ fn display_workspace_path(path: &Path) -> String {
     path.to_string_lossy().to_string()
 }
 
-/// One row per workspace flag: (enabled, card label, tag label). Single source
-/// of truth for flag order and naming across the card and table renderings.
+/// One row per workspace flag: (enabled, card label, tag label, form label).
+/// Single source of truth for flag order and naming across the card and table
+/// renderings and the interactive TUI edit form. The form label is the short,
+/// state-independent name the TUI shows next to its checkboxes (no "(ready)"
+/// suffix, which only makes sense for a read-only view).
 fn workspace_flag_entries(
     flags: WorkspaceFlags,
     search_ready: bool,
-) -> [(bool, &'static str, &'static str); 6] {
+) -> [(bool, &'static str, &'static str, &'static str); 6] {
     let (search_card, search_tag) = if flags.enable_search && search_ready {
         ("Search (ready)", "Search ready")
     } else {
         ("Search", "Search")
     };
     [
-        (flags.enable_search, search_card, search_tag),
-        (flags.enable_viewed, "Viewed tracking", "Viewed"),
-        (flags.enable_edit, "Edit", "Edit"),
-        (flags.enable_live, "Live", "Live"),
-        (flags.enable_chat, "Chat", "Chat"),
-        (flags.shared_annotation, "Shared notes", "Shared notes"),
+        (flags.enable_search, search_card, search_tag, "Search"),
+        (
+            flags.enable_viewed,
+            "Viewed tracking",
+            "Viewed",
+            "Viewed tracking",
+        ),
+        (flags.enable_edit, "Edit", "Edit", "Edit"),
+        (flags.enable_live, "Live", "Live", "Live"),
+        (flags.enable_chat, "Chat", "Chat", "Chat"),
+        (
+            flags.shared_annotation,
+            "Shared notes",
+            "Shared notes",
+            "Shared notes",
+        ),
     ]
+}
+
+/// Mutable, ordered accessor over the six workspace flags. Indexed identically
+/// to [`workspace_flag_entries`], so the TUI edit form can toggle "row N"
+/// without a second, drift-prone index→field map: display order and toggle
+/// order share one definition.
+fn workspace_flag_mut(flags: &mut WorkspaceFlags, idx: usize) -> &mut bool {
+    match idx {
+        0 => &mut flags.enable_search,
+        1 => &mut flags.enable_viewed,
+        2 => &mut flags.enable_edit,
+        3 => &mut flags.enable_live,
+        4 => &mut flags.enable_chat,
+        5 => &mut flags.shared_annotation,
+        other => panic!("workspace flag index {other} out of range (0..6)"),
+    }
 }
 
 fn format_workspace_flags(flags: WorkspaceFlags, search_ready: bool, colors: CliColors) -> String {
     workspace_flag_entries(flags, search_ready)
         .into_iter()
-        .map(|(enabled, card_label, _)| {
+        .map(|(enabled, card_label, _, _)| {
             let plain = format!("[{}] {card_label}", if enabled { "x" } else { " " });
             if enabled {
                 colors.enabled_flag(&plain)
@@ -290,8 +340,8 @@ fn format_workspace_flags(flags: WorkspaceFlags, search_ready: bool, colors: Cli
 fn format_workspace_feature_tags(flags: WorkspaceFlags, search_ready: bool) -> String {
     let features: Vec<&str> = workspace_flag_entries(flags, search_ready)
         .into_iter()
-        .filter(|(enabled, _, _)| *enabled)
-        .map(|(_, _, tag_label)| tag_label)
+        .filter(|(enabled, _, _, _)| *enabled)
+        .map(|(_, _, tag_label, _)| tag_label)
         .collect();
     if features.is_empty() {
         "-".to_string()
@@ -773,7 +823,14 @@ async fn main() {
     init_tracing();
     let cli = Cli::parse();
     let cli_entry = cli.entry.clone();
-    println!("Markon v{}", env!("CARGO_PKG_VERSION"));
+    // Suppress the version banner when we're about to enter the full-screen
+    // browser: it would flash on the primary screen just before EnterAlternateScreen
+    // and remain as the only on-screen residue after LeaveAlternateScreen on quit.
+    let launching_tui =
+        matches!(&cli.command, Some(Commands::Ls { format: None })) && tui_enabled();
+    if !launching_tui {
+        println!("Markon v{}", env!("CARGO_PKG_VERSION"));
+    }
 
     // Handle subcommands.
     if let Some(cmd) = cli.command {
@@ -821,14 +878,64 @@ async fn main() {
                 } else {
                     lock_host.clone()
                 };
-                list_workspaces(
-                    &bind_host,
-                    &advertised_host,
-                    &server,
-                    format,
-                    cli_entry.as_deref(),
-                )
-                .await
+                match format {
+                    // Explicit --format cards|table: static render, byte-for-byte
+                    // as before.
+                    Some(fmt) => {
+                        list_workspaces(
+                            &bind_host,
+                            &advertised_host,
+                            &server,
+                            fmt,
+                            cli_entry.as_deref(),
+                        )
+                        .await
+                    }
+                    // Bare `markon ls` on a capable interactive terminal → the
+                    // full-screen browser. `launching_tui` folds in the TTY +
+                    // capability gate (and the banner was suppressed above).
+                    None if launching_tui => {
+                        let port = server.port();
+                        // Hop onto a blocking-pool thread: the TUI loop is
+                        // synchronous crossterm, and control calls run via
+                        // Handle::block_on there (legal only off a runtime core
+                        // worker — see tui::ls::run). spawn_blocking parks a pool
+                        // thread while the multi-thread runtime's core workers keep
+                        // driving the IO reactor the async transport needs.
+                        let handle = tokio::runtime::Handle::current();
+                        let tui_server = server.clone();
+                        let tui_entry = cli_entry.clone();
+                        let join = tokio::task::spawn_blocking(move || {
+                            tui::ls::run(
+                                tui_server,
+                                handle,
+                                bind_host,
+                                advertised_host,
+                                port,
+                                tui_entry,
+                            )
+                        })
+                        .await;
+                        match join {
+                            Ok(inner) => inner.map_err(|e| -> Box<dyn std::error::Error> { e }),
+                            Err(join_err) => {
+                                Err(format!("interactive browser task failed: {join_err}").into())
+                            }
+                        }
+                    }
+                    // Bare `markon ls` piped / redirected / non-capable terminal →
+                    // today's default static cards.
+                    None => {
+                        list_workspaces(
+                            &bind_host,
+                            &advertised_host,
+                            &server,
+                            WorkspaceListFormat::Cards,
+                            cli_entry.as_deref(),
+                        )
+                        .await
+                    }
+                }
             }
             Commands::Detach { target } => detach_workspace(&server, &target).await,
             Commands::Set {

--- a/crates/cli/src/tui/ls.rs
+++ b/crates/cli/src/tui/ls.rs
@@ -19,6 +19,11 @@ enum Screen {
     ConfirmDetach,
 }
 
+enum Status {
+    Info(String),
+    Error(String),
+}
+
 /// Entry point for the interactive browser. Runs on a blocking-pool thread (see
 /// the `spawn_blocking` in `main`), where [`Handle::block_on`] is legal for the
 /// async control calls.
@@ -90,8 +95,9 @@ struct App {
     /// nothing is sent until save.
     edit_flags: WorkspaceFlags,
     edit_cursor: usize,
-    /// Transient message shown as a colored status line (control errors, etc.).
-    status: Option<String>,
+    /// Transient message shown below the current screen. Errors are red;
+    /// successful operations remain neutral instead of looking like failures.
+    status: Option<Status>,
     show_help: bool,
 }
 
@@ -156,10 +162,8 @@ impl App {
             Action::Up | Action::Char('k') => {
                 self.selected = self.selected.saturating_sub(1);
             }
-            Action::Down | Action::Char('j') => {
-                if !self.workspaces.is_empty() {
-                    self.selected = (self.selected + 1).min(self.workspaces.len() - 1);
-                }
+            Action::Down | Action::Char('j') if !self.workspaces.is_empty() => {
+                self.selected = (self.selected + 1).min(self.workspaces.len() - 1);
             }
             Action::Char('e') | Action::Enter => {
                 if let Some(ws) = self.selected_ws() {
@@ -169,17 +173,18 @@ impl App {
                     self.screen = Screen::Edit;
                 }
             }
-            Action::Char('d') => {
-                if self.selected_ws().is_some() {
-                    self.status = None;
-                    self.screen = Screen::ConfirmDetach;
-                }
+            Action::Char('d') if self.selected_ws().is_some() => {
+                self.status = None;
+                self.screen = Screen::ConfirmDetach;
             }
             Action::Char('o') => {
                 if let Some(url) = self.selected_url() {
                     match open::that(&url) {
-                        Ok(()) => self.status = Some(format!("opened {url}")),
-                        Err(e) => self.status = Some(format!("failed to open browser: {e}")),
+                        Ok(()) => self.status = Some(Status::Info(format!("opened {url}"))),
+                        Err(e) => {
+                            self.status =
+                                Some(Status::Error(format!("failed to open browser: {e}")))
+                        }
                     }
                 }
             }
@@ -231,13 +236,13 @@ impl App {
             Ok(()) => {
                 self.screen = Screen::List;
                 if let Err(e) = self.refresh() {
-                    self.status = Some(e);
+                    self.status = Some(Status::Error(e));
                 } else {
-                    self.status = Some(format!("saved {name}"));
+                    self.status = Some(Status::Info(format!("saved {name}")));
                 }
             }
             // Stay on Edit and surface the error; the working copy is preserved.
-            Err(e) => self.status = Some(e.to_string()),
+            Err(e) => self.status = Some(Status::Error(e.to_string())),
         }
         true
     }
@@ -246,21 +251,21 @@ impl App {
 
     fn handle_confirm(&mut self, action: Action) -> bool {
         match action {
-            Action::Char('y') => {
+            Action::Char('y') | Action::Char('Y') => {
                 if let Some(ws) = self.selected_ws() {
                     let id = ws.id.clone();
                     let name = display_name(ws);
                     match self.handle.block_on(self.server.remove_workspace(&id)) {
                         Ok(()) => match self.refresh() {
-                            Ok(()) => self.status = Some(format!("detached {name}")),
-                            Err(e) => self.status = Some(e),
+                            Ok(()) => self.status = Some(Status::Info(format!("detached {name}"))),
+                            Err(e) => self.status = Some(Status::Error(e)),
                         },
-                        Err(e) => self.status = Some(e.to_string()),
+                        Err(e) => self.status = Some(Status::Error(e.to_string())),
                     }
                 }
                 self.screen = Screen::List;
             }
-            Action::Char('n') | Action::Esc => {
+            Action::Char('n') | Action::Char('N') | Action::Esc => {
                 self.screen = Screen::List;
             }
             _ => {}
@@ -291,7 +296,22 @@ impl App {
             return frame.render();
         }
 
-        for (i, ws) in self.workspaces.iter().enumerate() {
+        // Keep the selected row visible while reserving terminal rows for the
+        // URL, help, and status. Without a viewport, moving below the physical
+        // screen made the cursor and mutation feedback disappear.
+        let fixed_rows = 6 + usize::from(self.show_help) + usize::from(self.status.is_some()) * 2;
+        let visible_rows = frame
+            .height()
+            .saturating_sub(fixed_rows)
+            .min(self.workspaces.len());
+        let start = viewport_start(self.selected, self.workspaces.len(), visible_rows);
+        for (i, ws) in self
+            .workspaces
+            .iter()
+            .enumerate()
+            .skip(start)
+            .take(visible_rows)
+        {
             let marker = if i == self.selected { "> " } else { "  " };
             let features = crate::format_workspace_feature_tags(ws.flags, ws.search_ready);
             let row = format!(
@@ -367,9 +387,16 @@ impl App {
     }
 
     fn push_status(&self, frame: &mut Frame) {
-        if let Some(status) = self.status.as_deref() {
-            frame.blank();
-            frame.line_colored(status, ERROR_COLOR);
+        match &self.status {
+            Some(Status::Info(message)) => {
+                frame.blank();
+                frame.line(message);
+            }
+            Some(Status::Error(message)) => {
+                frame.blank();
+                frame.line_colored(message, ERROR_COLOR);
+            }
+            None => {}
         }
     }
 }
@@ -377,6 +404,17 @@ impl App {
 /// Number of editable feature flags — the row count of the Edit form and the
 /// clamp bound for its cursor. Matches [`crate::workspace_flag_entries`].
 const FLAG_COUNT: usize = 6;
+
+fn viewport_start(selected: usize, total: usize, visible: usize) -> usize {
+    if visible == 0 || total <= visible {
+        0
+    } else {
+        selected
+            .saturating_add(1)
+            .saturating_sub(visible)
+            .min(total - visible)
+    }
+}
 
 /// User-visible name for a workspace row: the alias when set, else the shortened
 /// path. Ephemeral single-file workspaces join their serving root with the file
@@ -392,4 +430,19 @@ fn display_name(ws: &WorkspaceInfo) -> String {
         _ => base.to_path_buf(),
     };
     crate::display_workspace_path(&path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::viewport_start;
+
+    #[test]
+    fn viewport_keeps_selection_visible() {
+        assert_eq!(viewport_start(0, 10, 4), 0);
+        assert_eq!(viewport_start(3, 10, 4), 0);
+        assert_eq!(viewport_start(4, 10, 4), 1);
+        assert_eq!(viewport_start(9, 10, 4), 6);
+        assert_eq!(viewport_start(9, 10, 0), 0);
+        assert_eq!(viewport_start(2, 3, 4), 0);
+    }
 }

--- a/crates/cli/src/tui/ls.rs
+++ b/crates/cli/src/tui/ls.rs
@@ -1,0 +1,395 @@
+//! The interactive `markon ls` screen — the pilot that exercises the generic
+//! [`crate::tui`] layer. Everything workspace-specific (rows, feature summary,
+//! flag editing, detach) lives here; the terminal guard, frame/widget helpers,
+//! and key decoder come from the parent module.
+
+use super::{read_action, Action, Frame, TerminalGuard, ERROR_COLOR};
+use markon_core::control::RunningServer;
+use markon_core::server;
+use markon_core::workspace::{WorkspaceFlags, WorkspaceInfo};
+use std::error::Error;
+use std::io;
+use std::path::Path;
+use tokio::runtime::{Handle, RuntimeFlavor};
+
+/// Which screen currently owns the keyboard.
+enum Screen {
+    List,
+    Edit,
+    ConfirmDetach,
+}
+
+/// Entry point for the interactive browser. Runs on a blocking-pool thread (see
+/// the `spawn_blocking` in `main`), where [`Handle::block_on`] is legal for the
+/// async control calls.
+///
+/// # Runtime requirement
+/// The bridge is correct **only** on a multi-thread tokio runtime: while this
+/// blocking thread parks in `block_on`, the runtime's core workers must keep
+/// driving the IO reactor the async control transport needs. On a
+/// `current_thread` runtime the single thread would be blocked awaiting this
+/// task and nothing would drive the reactor — a silent deadlock. `main` uses the
+/// default multi-thread `#[tokio::main]`; the debug assertion below pins that
+/// invariant.
+///
+/// The initial fetch runs before any terminal state is touched, so its failure
+/// propagates as an error (mapping to a non-zero exit, consistent with the other
+/// management subcommands) without ever entering raw mode. Mid-session mutation
+/// failures (edit / detach) are surfaced on an in-UI status line instead and do
+/// not affect the exit status.
+pub fn run(
+    server: RunningServer,
+    handle: Handle,
+    bind_host: String,
+    advertised_host: String,
+    port: u16,
+    entry: Option<String>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    debug_assert_ne!(
+        handle.runtime_flavor(),
+        RuntimeFlavor::CurrentThread,
+        "the ls TUI bridge requires a multi-thread runtime: block_on here would \
+         deadlock the reactor on a current_thread runtime",
+    );
+
+    let (url_base, _use_entry_url) =
+        crate::resolve_workspace_list_base(&bind_host, &advertised_host, port, entry.as_deref());
+
+    // Initial fetch before touching the terminal: an error here propagates
+    // cleanly (non-zero exit) with no raw-mode side effects.
+    let workspaces = handle.block_on(server.list_workspaces())?;
+
+    let mut app = App {
+        server,
+        handle,
+        url_base,
+        workspaces,
+        selected: 0,
+        screen: Screen::List,
+        edit_flags: WorkspaceFlags::default(),
+        edit_cursor: 0,
+        status: None,
+        show_help: false,
+    };
+
+    // From here on the guard owns terminal restoration on every exit path.
+    let _guard = TerminalGuard::new()?;
+    app.event_loop()?;
+    Ok(())
+}
+
+struct App {
+    server: RunningServer,
+    handle: Handle,
+    /// Base URL (featured or `--entry` prefix) for building per-workspace URLs.
+    url_base: String,
+    workspaces: Vec<WorkspaceInfo>,
+    selected: usize,
+    screen: Screen,
+    /// Working copy of the selected workspace's flags while on the Edit screen;
+    /// nothing is sent until save.
+    edit_flags: WorkspaceFlags,
+    edit_cursor: usize,
+    /// Transient message shown as a colored status line (control errors, etc.).
+    status: Option<String>,
+    show_help: bool,
+}
+
+impl App {
+    fn event_loop(&mut self) -> io::Result<()> {
+        loop {
+            self.draw()?;
+            let action = read_action();
+            // Ctrl-C and a read error are global, screen-independent exits so we
+            // always unwind through the terminal guard.
+            if matches!(action, Action::CtrlC | Action::Quit) {
+                return Ok(());
+            }
+            let keep_running = match self.screen {
+                Screen::List => self.handle_list(action),
+                Screen::Edit => self.handle_edit(action),
+                Screen::ConfirmDetach => self.handle_confirm(action),
+            };
+            if !keep_running {
+                return Ok(());
+            }
+        }
+    }
+
+    // --- state helpers ---------------------------------------------------
+
+    fn selected_ws(&self) -> Option<&WorkspaceInfo> {
+        self.workspaces.get(self.selected)
+    }
+
+    /// Re-fetch the workspace list after a mutation and re-clamp the selection.
+    fn refresh(&mut self) -> Result<(), String> {
+        match self.handle.block_on(self.server.list_workspaces()) {
+            Ok(list) => {
+                self.workspaces = list;
+                self.clamp_selection();
+                Ok(())
+            }
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    fn clamp_selection(&mut self) {
+        if self.workspaces.is_empty() {
+            self.selected = 0;
+        } else if self.selected >= self.workspaces.len() {
+            self.selected = self.workspaces.len() - 1;
+        }
+    }
+
+    /// Full URL of the currently selected workspace, if any.
+    fn selected_url(&self) -> Option<String> {
+        self.selected_ws().map(|ws| {
+            server::build_workspace_url(&self.url_base, &server::workspace_url_path(&ws.id, None))
+        })
+    }
+
+    // --- List screen -----------------------------------------------------
+
+    fn handle_list(&mut self, action: Action) -> bool {
+        match action {
+            Action::Up | Action::Char('k') => {
+                self.selected = self.selected.saturating_sub(1);
+            }
+            Action::Down | Action::Char('j') => {
+                if !self.workspaces.is_empty() {
+                    self.selected = (self.selected + 1).min(self.workspaces.len() - 1);
+                }
+            }
+            Action::Char('e') | Action::Enter => {
+                if let Some(ws) = self.selected_ws() {
+                    self.edit_flags = ws.flags;
+                    self.edit_cursor = 0;
+                    self.status = None;
+                    self.screen = Screen::Edit;
+                }
+            }
+            Action::Char('d') => {
+                if self.selected_ws().is_some() {
+                    self.status = None;
+                    self.screen = Screen::ConfirmDetach;
+                }
+            }
+            Action::Char('o') => {
+                if let Some(url) = self.selected_url() {
+                    match open::that(&url) {
+                        Ok(()) => self.status = Some(format!("opened {url}")),
+                        Err(e) => self.status = Some(format!("failed to open browser: {e}")),
+                    }
+                }
+            }
+            Action::Char('?') => self.show_help = !self.show_help,
+            Action::Char('q') | Action::Esc => return false,
+            _ => {}
+        }
+        true
+    }
+
+    // --- Edit screen -----------------------------------------------------
+
+    fn handle_edit(&mut self, action: Action) -> bool {
+        match action {
+            Action::Up | Action::Char('k') => {
+                self.edit_cursor = self.edit_cursor.saturating_sub(1);
+            }
+            Action::Down | Action::Char('j') => {
+                self.edit_cursor = (self.edit_cursor + 1).min(FLAG_COUNT - 1);
+            }
+            Action::Space => {
+                let field = crate::workspace_flag_mut(&mut self.edit_flags, self.edit_cursor);
+                *field = !*field;
+            }
+            // Enter / s submit the working copy (AskUserQuestion-style: Enter is
+            // "confirm", Space toggles a row).
+            Action::Enter | Action::Char('s') => return self.save_edit(),
+            Action::Char('?') => self.show_help = !self.show_help,
+            // Esc backs out; q is reserved as "quit app" on List only, so it is
+            // inert here (the footer directs the user to Esc).
+            Action::Esc => {
+                self.status = None;
+                self.screen = Screen::List;
+            }
+            _ => {}
+        }
+        true
+    }
+
+    fn save_edit(&mut self) -> bool {
+        let Some(ws) = self.selected_ws() else {
+            self.screen = Screen::List;
+            return true;
+        };
+        let id = ws.id.clone();
+        let name = display_name(ws);
+        let flags = self.edit_flags;
+        match self.handle.block_on(self.server.update_flags(&id, flags)) {
+            Ok(()) => {
+                self.screen = Screen::List;
+                if let Err(e) = self.refresh() {
+                    self.status = Some(e);
+                } else {
+                    self.status = Some(format!("saved {name}"));
+                }
+            }
+            // Stay on Edit and surface the error; the working copy is preserved.
+            Err(e) => self.status = Some(e.to_string()),
+        }
+        true
+    }
+
+    // --- ConfirmDetach screen -------------------------------------------
+
+    fn handle_confirm(&mut self, action: Action) -> bool {
+        match action {
+            Action::Char('y') => {
+                if let Some(ws) = self.selected_ws() {
+                    let id = ws.id.clone();
+                    let name = display_name(ws);
+                    match self.handle.block_on(self.server.remove_workspace(&id)) {
+                        Ok(()) => match self.refresh() {
+                            Ok(()) => self.status = Some(format!("detached {name}")),
+                            Err(e) => self.status = Some(e),
+                        },
+                        Err(e) => self.status = Some(e.to_string()),
+                    }
+                }
+                self.screen = Screen::List;
+            }
+            Action::Char('n') | Action::Esc => {
+                self.screen = Screen::List;
+            }
+            _ => {}
+        }
+        true
+    }
+
+    // --- rendering -------------------------------------------------------
+
+    fn draw(&self) -> io::Result<()> {
+        match self.screen {
+            Screen::List => self.draw_list(),
+            Screen::Edit => self.draw_edit(),
+            Screen::ConfirmDetach => self.draw_confirm(),
+        }
+    }
+
+    fn draw_list(&self) -> io::Result<()> {
+        let mut frame = Frame::new()?;
+        frame.line(format!("Workspaces ({})", self.workspaces.len()));
+        frame.blank();
+
+        if self.workspaces.is_empty() {
+            frame.line("No active workspaces.");
+            frame.blank();
+            frame.line("q quit · ? help");
+            self.push_status(&mut frame);
+            return frame.render();
+        }
+
+        for (i, ws) in self.workspaces.iter().enumerate() {
+            let marker = if i == self.selected { "> " } else { "  " };
+            let features = crate::format_workspace_feature_tags(ws.flags, ws.search_ready);
+            let row = format!(
+                "{marker}{}. {}   {}   {}",
+                i + 1,
+                display_name(ws),
+                features,
+                ws.id
+            );
+            frame.selectable(row, i == self.selected);
+        }
+
+        frame.blank();
+        if let Some(url) = self.selected_url() {
+            frame.line(format!("URL: {url}"));
+        }
+        frame.blank();
+        frame.line("↑/↓ move · e edit · d detach · o open · q quit · ? help");
+        if self.show_help {
+            frame.line("aliases: k/j move · enter edit · ctrl-c quit");
+        }
+        self.push_status(&mut frame);
+        frame.render()
+    }
+
+    fn draw_edit(&self) -> io::Result<()> {
+        let mut frame = Frame::new()?;
+        let (name, path) = match self.selected_ws() {
+            Some(ws) => (
+                display_name(ws),
+                crate::display_workspace_path(Path::new(&ws.path)),
+            ),
+            None => (String::from("(none)"), String::new()),
+        };
+        frame.line(format!("Edit: {name}"));
+        if !path.is_empty() {
+            frame.line(path);
+        }
+        frame.blank();
+
+        // Rows, labels, and order all come from the single source of truth so
+        // the display and the toggle can never disagree.
+        for (i, (enabled, _, _, form_label)) in
+            crate::workspace_flag_entries(self.edit_flags, false)
+                .into_iter()
+                .enumerate()
+        {
+            frame.checkbox(enabled, form_label, i == self.edit_cursor);
+        }
+
+        frame.blank();
+        frame.line("↑/↓ move · space toggle · enter save · esc cancel · ? help");
+        if self.show_help {
+            frame.line("aliases: k/j move · s save · ctrl-c quit");
+        }
+        self.push_status(&mut frame);
+        frame.render()
+    }
+
+    fn draw_confirm(&self) -> io::Result<()> {
+        let mut frame = Frame::new()?;
+        let name = self
+            .selected_ws()
+            .map(display_name)
+            .unwrap_or_else(|| String::from("(none)"));
+        frame.line(format!("Detach \"{name}\"?"));
+        frame.blank();
+        frame.line("y = yes    n = no");
+        frame.blank();
+        frame.line("y detach · n cancel");
+        self.push_status(&mut frame);
+        frame.render()
+    }
+
+    fn push_status(&self, frame: &mut Frame) {
+        if let Some(status) = self.status.as_deref() {
+            frame.blank();
+            frame.line_colored(status, ERROR_COLOR);
+        }
+    }
+}
+
+/// Number of editable feature flags — the row count of the Edit form and the
+/// clamp bound for its cursor. Matches [`crate::workspace_flag_entries`].
+const FLAG_COUNT: usize = 6;
+
+/// User-visible name for a workspace row: the alias when set, else the shortened
+/// path. Ephemeral single-file workspaces join their serving root with the file
+/// name so the displayed path points at the actual file, not just its directory.
+fn display_name(ws: &WorkspaceInfo) -> String {
+    let alias = ws.alias.trim();
+    if !alias.is_empty() {
+        return alias.to_string();
+    }
+    let base = Path::new(&ws.path);
+    let path = match &ws.single_file {
+        Some(file) if ws.ephemeral => base.join(file),
+        _ => base.to_path_buf(),
+    };
+    crate::display_workspace_path(&path)
+}

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -29,6 +29,7 @@ use crossterm::{cursor, queue, QueueableCommand};
 use std::io::{self, Write};
 use std::panic::PanicHookInfo;
 use std::sync::Arc;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static>;
 
@@ -84,9 +85,12 @@ impl TerminalGuard {
 
         let mut out = io::stdout();
         out.queue(EnterAlternateScreen)?;
+        // EnterAlternateScreen is now queued and may already have reached a
+        // partially failing writer. Mark it active before any later fallible
+        // cursor/flush step so Drop always queues LeaveAlternateScreen.
+        guard.alt_active = true;
         out.queue(cursor::Hide)?;
         out.flush()?;
-        guard.alt_active = true;
 
         Ok(guard)
     }
@@ -225,6 +229,12 @@ impl Frame {
         self.line(String::new());
     }
 
+    /// Number of terminal rows available to this frame. Screens use this to
+    /// keep the current selection and status/footer inside the viewport.
+    pub fn height(&self) -> usize {
+        self.height as usize
+    }
+
     /// Append a line in the given foreground color (e.g. a red status line).
     pub fn line_colored(&mut self, text: impl Into<String>, color: Color) {
         self.lines.push(FrameLine {
@@ -278,20 +288,27 @@ impl Frame {
     }
 }
 
-/// Truncate `text` to at most `width` display columns. Width is approximated by
-/// `char` count, which is exact for the ASCII the screens emit; the important
-/// property is that `text` is escape-free, so no truncation ever splits an ANSI
-/// sequence or counts escape bytes as columns.
+/// Truncate `text` to at most `width` display columns. Workspace aliases and
+/// paths may contain CJK or other wide Unicode characters, so byte/char counts
+/// are insufficient: use terminal column widths and reserve one column for the
+/// ellipsis. Text is escape-free, so no truncation can split an ANSI sequence.
 fn truncate_to_width(text: &str, width: usize) -> String {
-    if text.chars().count() <= width {
+    if UnicodeWidthStr::width(text) <= width {
         text.to_string()
     } else if width == 0 {
         String::new()
     } else {
-        // Reserve the last column for an ellipsis marker so the reader sees the
-        // line was cut.
-        let keep = width.saturating_sub(1);
-        let mut out: String = text.chars().take(keep).collect();
+        let keep_width = width.saturating_sub(1);
+        let mut used = 0;
+        let mut out = String::new();
+        for ch in text.chars() {
+            let char_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+            if used + char_width > keep_width {
+                break;
+            }
+            out.push(ch);
+            used += char_width;
+        }
         out.push('…');
         out
     }
@@ -299,3 +316,17 @@ fn truncate_to_width(text: &str, width: usize) -> String {
 
 /// Red — the status-line color for a surfaced control-socket error.
 pub const ERROR_COLOR: Color = Color::Red;
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_to_width;
+
+    #[test]
+    fn truncates_by_terminal_columns() {
+        assert_eq!(truncate_to_width("abcdef", 4), "abc…");
+        assert_eq!(truncate_to_width("你好", 4), "你好");
+        assert_eq!(truncate_to_width("你好", 3), "你…");
+        assert_eq!(truncate_to_width("你好", 1), "…");
+        assert_eq!(truncate_to_width("abc", 0), "");
+    }
+}

--- a/crates/cli/src/tui/mod.rs
+++ b/crates/cli/src/tui/mod.rs
@@ -1,0 +1,301 @@
+//! Reusable terminal-UI layer for interactive CLI subcommands.
+//!
+//! This module is the **generic** half of the pilot: nothing here references
+//! workspaces, flags, or any `markon`-specific type. A future `tui/set.rs` (or
+//! any other interactive screen) reuses exactly this surface:
+//!
+//! - [`TerminalGuard`] — panic-safe RAII enter/leave of raw mode + the alternate
+//!   screen, plus a panic hook so a crash prints a legible backtrace on the
+//!   normal screen instead of a staircased mess wiped by teardown.
+//! - [`Frame`] — a full-redraw frame helper (Clear + MoveTo + flush) with a
+//!   width-aware, escape-free truncating line writer.
+//! - selectable-list, checkbox, and confirm helpers on [`Frame`] — the reusable
+//!   widgets the screens compose.
+//! - [`read_action`] — the shared key→action decoder, filtering key-release /
+//!   repeat events and intercepting Ctrl-C.
+//!
+//! Everything that knows about `WorkspaceInfo` / `WorkspaceFlags` lives in
+//! [`crate::tui::ls`].
+
+pub mod ls;
+
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
+use crossterm::style::{Color, Print, ResetColor, SetAttribute, SetForegroundColor};
+use crossterm::terminal::{
+    self, disable_raw_mode, enable_raw_mode, Clear, ClearType, EnterAlternateScreen,
+    LeaveAlternateScreen,
+};
+use crossterm::{cursor, queue, QueueableCommand};
+use std::io::{self, Write};
+use std::panic::PanicHookInfo;
+use std::sync::Arc;
+
+type PanicHook = Box<dyn Fn(&PanicHookInfo<'_>) + Sync + Send + 'static>;
+
+/// RAII guard that puts the terminal into full-screen raw mode on construction
+/// and *always* restores it on drop — normal return, `?`-early-return, and panic
+/// unwind alike.
+///
+/// The construction order matters for the "always restored" guarantee: the guard
+/// value is built (with both state flags cleared) **before** the first fallible
+/// terminal call, and each flag is set only after its step succeeds. So if
+/// `enable_raw_mode` succeeds but entering the alternate screen fails, the
+/// already-constructed guard still drops and disables raw mode — there is no
+/// partial-init window where raw mode is on but no guard exists.
+pub struct TerminalGuard {
+    raw_enabled: bool,
+    alt_active: bool,
+    /// The panic hook that was installed before us, wrapped so both our
+    /// terminal-restoring hook and `Drop` can reach it. Restored on drop.
+    prev_hook: Option<Arc<PanicHook>>,
+}
+
+impl TerminalGuard {
+    /// Enter raw mode + the alternate screen, hiding the cursor, and install a
+    /// terminal-restoring panic hook. Returns an error (having already restored)
+    /// if any step fails.
+    pub fn new() -> io::Result<Self> {
+        // Install the panic hook first so a panic during setup still restores the
+        // terminal before printing. The hook best-effort leaves raw mode / the
+        // alternate screen, then delegates to the previous hook on the normal
+        // screen where the backtrace renders legibly (raw mode suppresses the
+        // CR translation that otherwise staircases each line).
+        let prev = Arc::new(std::panic::take_hook());
+        {
+            let prev = prev.clone();
+            std::panic::set_hook(Box::new(move |info| {
+                let _ = disable_raw_mode();
+                let mut out = io::stdout();
+                let _ = queue!(out, LeaveAlternateScreen, cursor::Show);
+                let _ = out.flush();
+                prev(info);
+            }));
+        }
+
+        // Construct the guard up front so any error below still drops it.
+        let mut guard = TerminalGuard {
+            raw_enabled: false,
+            alt_active: false,
+            prev_hook: Some(prev),
+        };
+
+        enable_raw_mode()?;
+        guard.raw_enabled = true;
+
+        let mut out = io::stdout();
+        out.queue(EnterAlternateScreen)?;
+        out.queue(cursor::Hide)?;
+        out.flush()?;
+        guard.alt_active = true;
+
+        Ok(guard)
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        // Best-effort restore; ignore errors — there is nothing useful to do if
+        // the terminal itself is gone.
+        if self.alt_active {
+            let mut out = io::stdout();
+            let _ = queue!(out, cursor::Show, LeaveAlternateScreen);
+            let _ = out.flush();
+        }
+        if self.raw_enabled {
+            let _ = disable_raw_mode();
+        }
+        if let Some(prev) = self.prev_hook.take() {
+            // Drop our wrapper hook, then reinstate the original. When unwinding
+            // is not in flight our wrapper is the only other Arc holder, so
+            // `try_unwrap` recovers the original box verbatim.
+            let _ = std::panic::take_hook();
+            match Arc::try_unwrap(prev) {
+                Ok(hook) => std::panic::set_hook(hook),
+                Err(shared) => std::panic::set_hook(Box::new(move |info| shared(info))),
+            }
+        }
+    }
+}
+
+/// A semantic key/terminal event, decoded once so every screen matches the same
+/// vocabulary. Key-release and key-repeat events are filtered out before this is
+/// produced (crossterm delivers Press/Release/Repeat on Windows; matching all of
+/// them would double every keystroke).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    Up,
+    Down,
+    Left,
+    Right,
+    Enter,
+    Space,
+    Esc,
+    Char(char),
+    /// Ctrl-C — a global "quit now" that every screen honors, since raw mode
+    /// suppresses SIGINT so this arrives only as a key event.
+    CtrlC,
+    /// The terminal was resized; the caller should just redraw.
+    Resize,
+    /// `event::read()` returned an error (or an interrupted read). Treated as a
+    /// graceful quit so the guard restores the terminal rather than panicking
+    /// with an opaque, backtrace-garbling unwrap.
+    Quit,
+}
+
+/// Block until the next meaningful [`Action`]. Non-key events other than resize
+/// (mouse / focus / paste) and key-release / key-repeat events are looped past.
+pub fn read_action() -> Action {
+    loop {
+        match event::read() {
+            Ok(Event::Key(key)) => {
+                if key.kind != KeyEventKind::Press {
+                    // Ignore Release / Repeat: on Windows every keystroke would
+                    // otherwise fire twice.
+                    continue;
+                }
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && matches!(key.code, KeyCode::Char('c') | KeyCode::Char('C'))
+                {
+                    return Action::CtrlC;
+                }
+                return match key.code {
+                    KeyCode::Up => Action::Up,
+                    KeyCode::Down => Action::Down,
+                    KeyCode::Left => Action::Left,
+                    KeyCode::Right => Action::Right,
+                    KeyCode::Enter => Action::Enter,
+                    KeyCode::Char(' ') => Action::Space,
+                    KeyCode::Esc => Action::Esc,
+                    KeyCode::Char(c) => Action::Char(c),
+                    // Unmapped key: keep waiting rather than surfacing a no-op.
+                    _ => continue,
+                };
+            }
+            Ok(Event::Resize(_, _)) => return Action::Resize,
+            // Mouse / focus / paste: ignore.
+            Ok(_) => continue,
+            // A read error (including EINTR-style interruption) is a graceful
+            // quit, not a panic.
+            Err(_) => return Action::Quit,
+        }
+    }
+}
+
+/// One rendered line in a [`Frame`]. Text is always escape-free plain text;
+/// attributes (reverse video, foreground color) are applied by the renderer via
+/// separate crossterm commands, never embedded as raw `\x1b[..m` bytes — so
+/// width-based truncation can never miscount columns or cut through an escape.
+struct FrameLine {
+    text: String,
+    reverse: bool,
+    color: Option<Color>,
+}
+
+/// A full-screen frame built up as plain-text lines, then painted in one pass
+/// (Clear + per-line MoveTo + flush). Lines past the terminal height are dropped
+/// so tiny terminals truncate instead of panicking or scrolling.
+pub struct Frame {
+    width: usize,
+    height: u16,
+    lines: Vec<FrameLine>,
+}
+
+impl Frame {
+    /// Snapshot the current terminal size and start an empty frame.
+    pub fn new() -> io::Result<Self> {
+        let (cols, rows) = terminal::size().unwrap_or((80, 24));
+        Ok(Frame {
+            width: cols.max(1) as usize,
+            height: rows.max(1),
+            lines: Vec::new(),
+        })
+    }
+
+    /// Append a plain line.
+    pub fn line(&mut self, text: impl Into<String>) {
+        self.lines.push(FrameLine {
+            text: text.into(),
+            reverse: false,
+            color: None,
+        });
+    }
+
+    /// Append a blank line.
+    pub fn blank(&mut self) {
+        self.line(String::new());
+    }
+
+    /// Append a line in the given foreground color (e.g. a red status line).
+    pub fn line_colored(&mut self, text: impl Into<String>, color: Color) {
+        self.lines.push(FrameLine {
+            text: text.into(),
+            reverse: false,
+            color: Some(color),
+        });
+    }
+
+    /// Widget: one row of a selectable list — reverse-video when `selected`.
+    pub fn selectable(&mut self, text: impl Into<String>, selected: bool) {
+        self.lines.push(FrameLine {
+            text: text.into(),
+            reverse: selected,
+            color: None,
+        });
+    }
+
+    /// Widget: a checkbox row — `[x] label` / `[ ] label`, reverse-video when
+    /// `selected`. The label is plain text; the box glyph is composed here.
+    pub fn checkbox(&mut self, checked: bool, label: impl AsRef<str>, selected: bool) {
+        let text = format!("[{}] {}", if checked { 'x' } else { ' ' }, label.as_ref());
+        self.selectable(text, selected);
+    }
+
+    /// Paint the whole frame in one pass and flush.
+    pub fn render(&self) -> io::Result<()> {
+        let mut out = io::stdout();
+        queue!(out, Clear(ClearType::All), cursor::MoveTo(0, 0))?;
+        for (i, line) in self.lines.iter().enumerate() {
+            if i as u16 >= self.height {
+                break;
+            }
+            queue!(out, cursor::MoveTo(0, i as u16))?;
+            let text = truncate_to_width(&line.text, self.width);
+            if line.reverse {
+                queue!(out, SetAttribute(crossterm::style::Attribute::Reverse))?;
+            }
+            if let Some(color) = line.color {
+                queue!(out, SetForegroundColor(color))?;
+            }
+            queue!(out, Print(text))?;
+            if line.color.is_some() {
+                queue!(out, ResetColor)?;
+            }
+            if line.reverse {
+                queue!(out, SetAttribute(crossterm::style::Attribute::Reset))?;
+            }
+        }
+        out.flush()
+    }
+}
+
+/// Truncate `text` to at most `width` display columns. Width is approximated by
+/// `char` count, which is exact for the ASCII the screens emit; the important
+/// property is that `text` is escape-free, so no truncation ever splits an ANSI
+/// sequence or counts escape bytes as columns.
+fn truncate_to_width(text: &str, width: usize) -> String {
+    if text.chars().count() <= width {
+        text.to_string()
+    } else if width == 0 {
+        String::new()
+    } else {
+        // Reserve the last column for an ellipsis marker so the reader sees the
+        // line was cut.
+        let keep = width.saturating_sub(1);
+        let mut out: String = text.chars().take(keep).collect();
+        out.push('…');
+        out
+    }
+}
+
+/// Red — the status-line color for a surfaced control-socket error.
+pub const ERROR_COLOR: Color = Color::Red;


### PR DESCRIPTION
## What

Bare `markon ls` on a capable interactive terminal now opens a full-screen
workspace browser:

- **↑/↓** (or `k`/`j`) select a workspace
- **`e`** (or Enter) edits feature flags; Space toggles, Enter/`s` saves
- **`d`** detaches after confirmation
- **`o`** opens the selected workspace URL
- **`q`** / Esc / Ctrl-C quits

Edits and detaches use the privileged control socket, matching `markon set` and
`markon detach` behavior.

## Backward compatibility

The interactive path is enabled only for capable terminals:

- Piped, redirected, dumb-terminal and CI invocations retain static cards.
- Explicit `--format cards|table` always remains static.
- `MARKON_NO_TUI=1` disables the TUI.

## Design and review hardening

The new `crates/cli/src/tui/` module provides a panic-safe terminal guard,
full-redraw frame and shared key decoder. The `ls` state machine covers list,
flag editing and detach confirmation.

Review fixes ensure the alternate screen is restored even if setup partially
fails, measure/truncate by terminal columns for CJK text, keep the selected row
visible on short terminals, distinguish informational and error status colors,
and accept uppercase confirmation keys.

Built on **crossterm 0.28** plus the lightweight **unicode-width** crate; no
ratatui dependency is introduced.

## Validation

- Full quality gate passes: fmt, Graphviz policy, clippy with warnings denied,
  Rust tests (19 + 307 + 2 + 13 + 3), npm lint and 462 frontend tests.
- Added unit coverage for Unicode column truncation and list viewport behavior.
- Interactive pseudo-terminal validation covered navigation, edit/save,
  detach confirmation, clean quit and terminal restoration.
