### PR TITLE
refactor: adopt CodeMirror for Markdown editing

### DIFF
--- a/crates/core/assets/css/editor.css
+++ b/crates/core/assets/css/editor.css
@@ -1908,150 +1908,157 @@ body.workspace-spotlight-open {
     overflow: hidden;
 }
 
-/* Line numbers gutter */
-.editor-line-numbers {
-    flex-shrink: 0;
-    width: 50px;
-    overflow-y: hidden;
-    overflow-x: hidden;
-    background-color: var(--mk-editor-gutter-bg);
-    border-right: 1px solid var(--mk-editor-gutter-border);
-    padding: 0;
-    user-select: none;
-    text-align: right;
-    font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
-    font-size: 14px;
-    line-height: 1.6;
-    color: var(--mk-editor-gutter-fg);
-}
-
-.editor-line-number {
-    padding-right: 12px;
-    height: 22.4px; /* Match line-height of textarea (14px * 1.6) */
-}
-
-/* Text container (holds both highlight layer and textarea) */
-.editor-text-container {
+/* CodeMirror owns text input, selection, line numbers, history, incremental
+   Markdown parsing and viewport rendering. Keep visual decisions in Markon's
+   editor tokens so every preset continues to work without component colours. */
+.editor-codemirror {
     flex: 1;
-    position: relative;
+    min-width: 0;
+    min-height: 0;
     height: 100%;
     overflow: hidden;
+    background-color: var(--mk-editor-bg);
 }
 
-/* Highlight layer (background, with syntax coloring) */
-.editor-highlight-layer {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    margin: 0;
-    padding: 0 0 0 12px;
-    font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
-    font-size: 14px;
-    line-height: 1.6;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    overflow-y: auto;
-    overflow-x: auto;
-    pointer-events: none;
+.editor-codemirror .cm-editor {
+    height: 100%;
     background-color: var(--mk-editor-bg);
     color: var(--mk-editor-fg);
-    tab-size: 4;
-    scrollbar-width: none; /* Firefox */
-}
-
-.editor-highlight-layer::-webkit-scrollbar {
-    display: none; /* Chrome/Safari */
-}
-
-.editor-highlight-layer code {
-    display: block;
-    font-family: inherit;
-    font-size: inherit;
-    line-height: inherit;
-    white-space: inherit;
-    word-wrap: inherit;
-}
-
-/* Textarea (foreground, transparent) */
-.editor-textarea {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: transparent;
-    color: transparent;
-    caret-color: var(--mk-editor-caret);
-    border: none;
     outline: none;
+}
+
+.editor-codemirror .cm-editor.cm-focused {
+    outline: none;
+}
+
+.editor-codemirror .cm-scroller {
+    overflow: auto;
     font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
     font-size: 14px;
     line-height: 1.6;
-    padding: 0 0 0 12px;
-    resize: none;
     tab-size: 4;
-    overflow-y: auto;
-    overflow-x: auto;
 }
 
-.editor-textarea::selection {
+.editor-codemirror .cm-content {
+    min-height: 100%;
+    padding: 0;
+    caret-color: var(--mk-editor-caret);
+}
+
+.editor-codemirror .cm-line {
+    padding: 0 12px;
+}
+
+.editor-codemirror .cm-gutters {
+    min-height: 100%;
+    background-color: var(--mk-editor-gutter-bg);
+    color: var(--mk-editor-gutter-fg);
+    border-right: 1px solid var(--mk-editor-gutter-border);
+}
+
+.editor-codemirror .cm-gutterElement {
+    padding: 0 12px 0 8px;
+}
+
+.editor-codemirror .cm-activeLine,
+.editor-codemirror .cm-activeLineGutter {
+    background-color: color-mix(in srgb, var(--mk-editor-accent) 8%, transparent);
+}
+
+.editor-codemirror .cm-cursor,
+.editor-codemirror .cm-dropCursor {
+    border-left-color: var(--mk-editor-caret);
+}
+
+.editor-codemirror .cm-selectionBackground,
+.editor-codemirror .cm-content ::selection {
     background-color: var(--mk-editor-selection);
-    color: transparent;
 }
 
-/* Markdown syntax highlighting — colours come from the active editor
-   preset (--mk-editor-syn-*; follow-page tracks data-theme). */
-.md-header {
+.editor-codemirror .cm-matchingBracket {
+    background-color: color-mix(in srgb, var(--mk-editor-accent) 18%, transparent);
+    outline: 1px solid var(--mk-editor-accent);
+}
+
+.editor-codemirror .cm-searchMatch {
+    background-color: color-mix(in srgb, var(--markon-warning) 28%, transparent);
+    outline: 1px solid color-mix(in srgb, var(--markon-warning) 70%, transparent);
+}
+
+.editor-codemirror .cm-searchMatch.cm-searchMatch-selected {
+    background-color: color-mix(in srgb, var(--mk-editor-accent) 24%, transparent);
+    outline-color: var(--mk-editor-accent);
+}
+
+.editor-codemirror .cm-panels,
+.editor-codemirror .cm-tooltip {
+    background-color: var(--mk-editor-header-bg);
+    color: var(--mk-editor-chrome-fg-strong);
+    border-color: var(--mk-editor-header-border);
+}
+
+.editor-codemirror .cm-panels input,
+.editor-codemirror .cm-panels button {
+    background-color: var(--mk-editor-bg);
+    color: var(--mk-editor-fg);
+    border: 1px solid var(--mk-editor-gutter-border);
+}
+
+.editor-codemirror .cm-foldPlaceholder {
+    background-color: var(--mk-editor-gutter-bg);
+    color: var(--mk-editor-gutter-fg);
+    border-color: var(--mk-editor-gutter-border);
+}
+
+/* Markdown syntax highlighting supplied through a stable CodeMirror
+   tagHighlighter. The parser updates these ranges incrementally. */
+.editor-codemirror .mk-cm-heading {
     color: var(--mk-editor-syn-header);
     font-weight: bold;
 }
 
-.md-header-text {
-    color: var(--mk-editor-syn-header-text);
-    font-weight: bold;
-}
-
-.md-bold {
+.editor-codemirror .mk-cm-strong {
     color: var(--mk-editor-syn-bold);
     font-weight: bold;
 }
 
-.md-italic {
+.editor-codemirror .mk-cm-emphasis {
     color: var(--mk-editor-syn-italic);
     font-style: italic;
 }
 
-.md-code {
+.editor-codemirror .mk-cm-code {
     color: var(--mk-editor-syn-code);
     background-color: var(--mk-editor-syn-code-bg);
 }
 
-.md-code-fence {
-    color: var(--mk-editor-syn-fence);
-}
-
-.md-link {
+.editor-codemirror .mk-cm-link {
     color: var(--mk-editor-syn-link);
+    text-decoration: underline;
+    text-underline-offset: 2px;
 }
 
-.md-image {
-    color: var(--mk-editor-syn-image);
-}
-
-.md-quote {
+.editor-codemirror .mk-cm-quote,
+.editor-codemirror .mk-cm-comment {
     color: var(--mk-editor-syn-quote);
 }
 
-.md-list {
+.editor-codemirror .mk-cm-list {
     color: var(--mk-editor-syn-list);
 }
 
-.md-hr {
+.editor-codemirror .mk-cm-separator {
     color: var(--mk-editor-syn-hr);
 }
 
+.editor-codemirror .mk-cm-meta {
+    color: var(--mk-editor-syn-fence);
+}
+
+.editor-codemirror .mk-cm-invalid {
+    color: var(--markon-danger);
+    text-decoration: underline wavy;
+}
 
 .editor-save-btn {
     background-color: var(--mk-editor-btn-bg);

--- a/crates/core/assets/css/editor.css
+++ b/crates/core/assets/css/editor.css
@@ -1766,7 +1766,7 @@ body.workspace-spotlight-open {
 
 /* ============================================================
    EDITOR MODAL
-   Minimalist Markdown source editor with line numbers
+   CodeMirror-powered Markdown source editor
    ============================================================ */
 
 .editor-modal {
@@ -1900,12 +1900,6 @@ body.workspace-spotlight-open {
 .editor-tab.active {
     color: var(--mk-editor-chrome-fg-strong);
     border-bottom-color: var(--mk-editor-accent);
-}
-
-.editor-container {
-    display: flex;
-    height: 100%;
-    overflow: hidden;
 }
 
 /* CodeMirror owns text input, selection, line numbers, history, incremental

--- a/crates/core/assets/css/tokens.css
+++ b/crates/core/assets/css/tokens.css
@@ -225,14 +225,12 @@
     --mk-editor-btn-disabled-fg:  var(--markon-fg-subtle);
     /* markdown syntax — light (GitHub-light, preserves the prior light editor) */
     --mk-editor-syn-header:       #0550ae;
-    --mk-editor-syn-header-text:  #0a3069;
     --mk-editor-syn-bold:         #8250df;
     --mk-editor-syn-italic:       #cf222e;
     --mk-editor-syn-code:         #a40e26;
     --mk-editor-syn-code-bg:      rgba(175, 184, 193, 0.2);
     --mk-editor-syn-fence:        #57606a;
     --mk-editor-syn-link:         #0969da;
-    --mk-editor-syn-image:        #8250df;
     --mk-editor-syn-quote:        #1a7f37;
     --mk-editor-syn-list:         #8250df;
     --mk-editor-syn-hr:           #57606a;
@@ -427,14 +425,12 @@ html[data-theme="dark"] {
        The chrome vars need no dark entries: they reference page tokens
        that already switch in this block. */
     --mk-editor-syn-header:       #79c0ff;
-    --mk-editor-syn-header-text:  #7ee787;
     --mk-editor-syn-bold:         #d2a8ff;
     --mk-editor-syn-italic:       #ff7b72;
     --mk-editor-syn-code:         #ffa657;
     --mk-editor-syn-code-bg:      rgba(255, 255, 255, 0.1);
     --mk-editor-syn-fence:        #8b949e;
     --mk-editor-syn-link:         #58a6ff;
-    --mk-editor-syn-image:        #d2a8ff;
     --mk-editor-syn-quote:        #7ee787;
     --mk-editor-syn-list:         #d2a8ff;
     --mk-editor-syn-hr:           #8b949e;
@@ -471,14 +467,12 @@ html[data-editor-theme="vscode-dark"] {
     --mk-editor-btn-disabled-bg:  #4d4d4d;
     --mk-editor-btn-disabled-fg:  #808080;
     --mk-editor-syn-header:       #569cd6;
-    --mk-editor-syn-header-text:  #4ec9b0;
     --mk-editor-syn-bold:         #dcdcaa;
     --mk-editor-syn-italic:       #ce9178;
     --mk-editor-syn-code:         #d16969;
     --mk-editor-syn-code-bg:      rgba(255, 255, 255, 0.1);
     --mk-editor-syn-fence:        #808080;
     --mk-editor-syn-link:         #3794ff;
-    --mk-editor-syn-image:        #c586c0;
     --mk-editor-syn-quote:        #6a9955;
     --mk-editor-syn-list:         #dcdcaa;
     --mk-editor-syn-hr:           #808080;

--- a/crates/core/assets/js/editor-codemirror.ts
+++ b/crates/core/assets/js/editor-codemirror.ts
@@ -1,0 +1,122 @@
+/**
+ * Lazily loaded CodeMirror runtime for the Markdown source editor.
+ *
+ * Keeping this module behind a dynamic import means ordinary document views
+ * do not download or parse the editor engine until the user opens Edit.
+ */
+
+import { basicSetup } from 'codemirror';
+import { indentWithTab } from '@codemirror/commands';
+import { indentUnit, syntaxHighlighting } from '@codemirror/language';
+import { markdown } from '@codemirror/lang-markdown';
+import {
+    EditorState,
+    Prec,
+    type StateCommand,
+    type Text as CodeMirrorText,
+} from '@codemirror/state';
+import { EditorView, keymap } from '@codemirror/view';
+import { tagHighlighter, tags } from '@lezer/highlight';
+
+export interface MarkdownEditorCallbacks {
+    onDocumentChanged: (doc: CodeMirrorText) => void;
+    onSave: () => void;
+    onSelectionChanged: () => void;
+}
+
+const markonMarkdownHighlighter = tagHighlighter([
+    { tag: tags.heading, class: 'mk-cm-heading' },
+    { tag: tags.strong, class: 'mk-cm-strong' },
+    { tag: tags.emphasis, class: 'mk-cm-emphasis' },
+    { tag: tags.monospace, class: 'mk-cm-code' },
+    { tag: [tags.link, tags.url], class: 'mk-cm-link' },
+    { tag: tags.quote, class: 'mk-cm-quote' },
+    { tag: tags.list, class: 'mk-cm-list' },
+    { tag: tags.contentSeparator, class: 'mk-cm-separator' },
+    { tag: [tags.meta, tags.processingInstruction], class: 'mk-cm-meta' },
+    { tag: tags.comment, class: 'mk-cm-comment' },
+    { tag: tags.invalid, class: 'mk-cm-invalid' },
+]);
+
+/**
+ * CodeMirror follows the conventional "empty item exits the list" behavior.
+ * Markon explicitly allows a marker-only item (#60), so preserve that one
+ * product-specific rule as a CodeMirror transaction and let markdownKeymap
+ * handle every other Enter case.
+ */
+const continueEmptyMarkdownList: StateCommand = ({ state, dispatch }) => {
+    if (state.selection.ranges.length !== 1) return false;
+    const selection = state.selection.main;
+    if (!selection.empty) return false;
+
+    const line = state.doc.lineAt(selection.head);
+    const beforeCursor = line.text.slice(0, selection.head - line.from);
+    const match = beforeCursor.match(
+        /^([\t ]*)(?:(\d+)\.|([-+*]))(?:[\t ]+(?:\[([ xX])\][\t ]*)?)?$/,
+    );
+    if (!match) return false;
+
+    const indent = match[1] ?? '';
+    const ordered = match[2];
+    const bullet = match[3];
+    const task = match[4] === undefined ? '' : '[ ] ';
+    const marker = ordered === undefined
+        ? bullet
+        : `${Number.parseInt(ordered, 10) + 1}.`;
+    if (!marker) return false;
+
+    const insert = `\n${indent}${marker} ${task}`;
+    dispatch?.(state.update({
+        changes: { from: selection.head, insert },
+        selection: { anchor: selection.head + insert.length },
+        scrollIntoView: true,
+        userEvent: 'input',
+    }));
+    return true;
+};
+
+export function createMarkdownEditor(
+    parent: HTMLElement,
+    doc: string,
+    callbacks: MarkdownEditorCallbacks,
+): EditorView {
+    return new EditorView({
+        doc,
+        parent,
+        extensions: [
+            // This binding must precede markdown() at the same high precedence
+            // so Markon's marker-only list behavior gets first refusal.
+            Prec.high(keymap.of([
+                {
+                    key: 'Mod-s',
+                    run: () => {
+                        callbacks.onSave();
+                        return true;
+                    },
+                },
+                { key: 'Enter', run: continueEmptyMarkdownList },
+                indentWithTab,
+            ])),
+            basicSetup,
+            markdown(),
+            EditorView.lineWrapping,
+            EditorState.tabSize.of(4),
+            indentUnit.of('    '),
+            syntaxHighlighting(markonMarkdownHighlighter),
+            EditorView.contentAttributes.of({
+                spellcheck: 'false',
+                autocapitalize: 'off',
+            }),
+            EditorView.updateListener.of(update => {
+                if (update.docChanged) {
+                    callbacks.onDocumentChanged(update.state.doc);
+                }
+                if (update.docChanged || update.selectionSet) {
+                    callbacks.onSelectionChanged();
+                }
+            }),
+        ],
+    });
+}
+
+export type CreateMarkdownEditor = typeof createMarkdownEditor;

--- a/crates/core/assets/js/editor-codemirror.ts
+++ b/crates/core/assets/js/editor-codemirror.ts
@@ -62,7 +62,7 @@ const continueEmptyMarkdownList: StateCommand = ({ state, dispatch }) => {
     const task = match[4] === undefined ? '' : '[ ] ';
     const marker = ordered === undefined
         ? bullet
-        : `${Number.parseInt(ordered, 10) + 1}.`;
+        : `${BigInt(ordered) + 1n}.`;
     if (!marker) return false;
 
     const insert = `\n${indent}${marker} ${task}`;

--- a/crates/core/assets/js/managers/editor-manager.test.ts
+++ b/crates/core/assets/js/managers/editor-manager.test.ts
@@ -46,13 +46,10 @@ function replaceDocument(view: EditorView, content: string): void {
 
 /** Stub jsdom-missing APIs the EditorManager touches. */
 function stubGlobals(): void {
-    if (!('confirm' in window)) {
-        // jsdom often omits `confirm`; provide a default that says "ok".
-        Object.defineProperty(window, 'confirm', { value: vi.fn(() => true), writable: true, configurable: true });
-    }
-    if (!('alert' in window)) {
-        Object.defineProperty(window, 'alert', { value: vi.fn(), writable: true, configurable: true });
-    }
+    // jsdom exposes alert/confirm placeholders that only print
+    // "Not implemented", so replace them even when the properties exist.
+    Object.defineProperty(window, 'confirm', { value: vi.fn(() => true), writable: true, configurable: true });
+    Object.defineProperty(window, 'alert', { value: vi.fn(), writable: true, configurable: true });
 }
 
 describe('EditorManager', () => {
@@ -101,6 +98,20 @@ describe('EditorManager', () => {
         expect(mgr.isDirty()).toBe(false);
     });
 
+    it('coalesces concurrent open() calls into one editor session', async () => {
+        seedOriginalMarkdown('# hello');
+        const mgr = new EditorManager('docs/test.md');
+
+        await Promise.all([
+            mgr.open(),
+            mgr.open({ line: 1 }),
+        ]);
+
+        expect(document.querySelectorAll('.editor-modal')).toHaveLength(1);
+        expect(document.querySelectorAll('.cm-editor')).toHaveLength(1);
+        expect(mgr.isOpen()).toBe(true);
+    });
+
     it('save() POSTs to /api/save with the canonical body shape and X-Markon-Token header', async () => {
         seedOriginalMarkdown('# hello');
         seedMeta('workspace-id', 'ws-42');
@@ -137,6 +148,57 @@ describe('EditorManager', () => {
             file_path: 'docs/test.md',
             content: '# changed',
         });
+    });
+
+    it('keeps edits made during save dirty and coalesces concurrent saves', async () => {
+        seedOriginalMarkdown('# initial');
+        let resolveSave!: (response: {
+            ok: boolean;
+            status: number;
+            text: () => Promise<string>;
+            json: () => Promise<{ success: boolean }>;
+        }) => void;
+        const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
+            if (url === '/api/save') {
+                return new Promise(resolve => {
+                    resolveSave = resolve;
+                });
+            }
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                text: async () => '',
+                json: async () => ({ html: '' }),
+            });
+        }) as unknown as typeof fetch;
+        vi.stubGlobal('fetch', fetchMock);
+
+        const mgr = new EditorManager('docs/test.md');
+        await mgr.open();
+        const view = getEditorView();
+        replaceDocument(view, '# sent');
+
+        const firstSave = mgr.save();
+        const duplicateSave = mgr.save();
+
+        replaceDocument(view, '# typed while saving');
+        resolveSave({
+            ok: true,
+            status: 200,
+            text: async () => '',
+            json: async () => ({ success: true }),
+        });
+        await Promise.all([firstSave, duplicateSave]);
+
+        const saveCalls = (fetchMock as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(
+            (call: unknown[]) => call[0] === '/api/save',
+        );
+        expect(saveCalls).toHaveLength(1);
+        expect(JSON.parse((itemAt(saveCalls, 0)[1] as RequestInit).body as string).content)
+            .toBe('# sent');
+        expect(view.state.doc.toString()).toBe('# typed while saving');
+        expect(mgr.isDirty()).toBe(true);
+        expect(document.querySelector<HTMLElement>('.editor-save-btn')?.style.display).toBe('block');
     });
 
     it('input events flip isDirty true and revert clears it back to false', async () => {
@@ -179,6 +241,13 @@ describe('EditorManager', () => {
             cursor: 10,
             expected: '- [x] done\n- [ ] ',
             caret: 17,
+        },
+        {
+            label: 'an ordered marker beyond Number.MAX_SAFE_INTEGER',
+            source: '9007199254740992. # heading',
+            cursor: 18,
+            expected: '9007199254740992. \n9007199254740993. # heading',
+            caret: 37,
         },
     ])('Enter continues $label and moves the caret atomically', async ({ source, cursor, expected, caret }) => {
         seedOriginalMarkdown(source);
@@ -232,6 +301,28 @@ describe('EditorManager', () => {
         // A second editor instance restores the saved preference.
         const split = document.querySelector<HTMLElement>('.editor-split');
         expect(split?.classList.contains('editor-layout-full')).toBe(true);
+    });
+
+    it('resets the narrow-screen tab to Edit when an export editor reopens', async () => {
+        Object.defineProperty(window, 'innerWidth', { value: 600, configurable: true, writable: true });
+        vi.stubGlobal('fetch', vi.fn(async () => ({
+            ok: true,
+            status: 200,
+            text: async () => '',
+            json: async () => ({ html: '' }),
+        })));
+        const mgr = new EditorManager('a.md');
+
+        await mgr.open({ mode: 'export', content: 'first' });
+        document.querySelector<HTMLButtonElement>('.editor-tab-preview')?.click();
+        expect(document.querySelector('.editor-tab-preview')?.classList.contains('active')).toBe(true);
+        mgr.close();
+
+        await mgr.open({ mode: 'export', content: 'second' });
+        expect(document.querySelector('.editor-tab-edit')?.classList.contains('active')).toBe(true);
+        expect(document.querySelector<HTMLElement>('.editor-pane-source')?.style.display).toBe('flex');
+        expect(document.querySelector<HTMLElement>('.editor-pane-preview')?.style.display).toBe('none');
+        mgr.close();
     });
 
     it('Escape key triggers close()', async () => {
@@ -329,5 +420,65 @@ describe('EditorManager', () => {
             workspace_id: 'ws-42',
             content: '```mermaid\ngraph TD; A-->B\n```',
         });
+    });
+
+    it('ignores a stale preview response that arrives after a newer render', async () => {
+        seedOriginalMarkdown('preview-old-session');
+        const pending: Array<{
+            content: string;
+            resolve: (response: {
+                ok: boolean;
+                status: number;
+                json: () => Promise<{ html: string }>;
+            }) => void;
+        }> = [];
+        const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+            if (url !== '/api/preview') {
+                return Promise.resolve({
+                    ok: true,
+                    status: 200,
+                    json: async () => ({ success: true }),
+                });
+            }
+            const content = JSON.parse(init?.body as string).content as string;
+            return new Promise(resolve => {
+                pending.push({ content, resolve });
+            });
+        }) as unknown as typeof fetch;
+        vi.stubGlobal('fetch', fetchMock);
+
+        const mgr = new EditorManager('a.md');
+        await mgr.open();
+        await vi.waitFor(() => {
+            expect(pending.filter(request => request.content.startsWith('preview-'))).toHaveLength(1);
+        });
+
+        replaceDocument(getEditorView(), 'preview-new-session');
+        await vi.waitFor(() => {
+            expect(pending.filter(request => request.content.startsWith('preview-'))).toHaveLength(2);
+        });
+        const sessionRequests = pending.filter(request => request.content.startsWith('preview-'));
+        const newest = itemAt(sessionRequests, 1);
+        expect(newest.content).toBe('preview-new-session');
+        newest.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({ html: '<p id="new-preview">new</p>' }),
+        });
+        await vi.waitFor(() => {
+            expect(document.querySelector('#new-preview')?.textContent).toBe('new');
+        });
+
+        const stale = itemAt(sessionRequests, 0);
+        stale.resolve({
+            ok: true,
+            status: 200,
+            json: async () => ({ html: '<p id="old-preview">old</p>' }),
+        });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(document.querySelector('#new-preview')?.textContent).toBe('new');
+        expect(document.querySelector('#old-preview')).toBeNull();
     });
 });

--- a/crates/core/assets/js/managers/editor-manager.test.ts
+++ b/crates/core/assets/js/managers/editor-manager.test.ts
@@ -135,6 +135,77 @@ describe('EditorManager', () => {
         expect(mgr.isDirty()).toBe(false);
     });
 
+    it.each([
+        {
+            label: 'an empty ordered marker before existing text',
+            source: '1. # heading',
+            cursor: 3,
+            expected: '1. \n2. # heading',
+            caret: 7,
+        },
+        {
+            label: 'an empty unordered marker',
+            source: '-',
+            cursor: 1,
+            expected: '-\n- ',
+            caret: 4,
+        },
+        {
+            label: 'a populated ordered item',
+            source: '9. item',
+            cursor: 7,
+            expected: '9. item\n10. ',
+            caret: 12,
+        },
+        {
+            label: 'a checked task item',
+            source: '- [x] done',
+            cursor: 10,
+            expected: '- [x] done\n- [ ] ',
+            caret: 17,
+        },
+    ])('Enter continues $label and moves the caret atomically', async ({ source, cursor, expected, caret }) => {
+        seedOriginalMarkdown(source);
+        const mgr = new EditorManager('a.md');
+        await mgr.open();
+        const ta = document.querySelector<HTMLTextAreaElement>('.editor-textarea')!;
+        ta.setSelectionRange(cursor, cursor);
+
+        const enter = new KeyboardEvent('keydown', {
+            key: 'Enter',
+            bubbles: true,
+            cancelable: true,
+        });
+        ta.dispatchEvent(enter);
+
+        expect(enter.defaultPrevented).toBe(true);
+        expect(ta.value).toBe(expected);
+        expect(ta.selectionStart).toBe(caret);
+        expect(ta.selectionEnd).toBe(caret);
+        expect(mgr.isDirty()).toBe(true);
+    });
+
+    it('modified Enter keeps the browser native behavior', async () => {
+        seedOriginalMarkdown('- item');
+        const mgr = new EditorManager('a.md');
+        await mgr.open();
+        const ta = document.querySelector<HTMLTextAreaElement>('.editor-textarea')!;
+        ta.setSelectionRange(ta.value.length, ta.value.length);
+
+        const enter = new KeyboardEvent('keydown', {
+            key: 'Enter',
+            shiftKey: true,
+            bubbles: true,
+            cancelable: true,
+        });
+        ta.dispatchEvent(enter);
+
+        expect(enter.defaultPrevented).toBe(false);
+        // jsdom does not apply the browser's native key action; unchanged text
+        // confirms that the list continuation handler stayed out of the way.
+        expect(ta.value).toBe('- item');
+    });
+
     it('layout toggle persists "full" to localStorage and loads it back', async () => {
         seedOriginalMarkdown('x');
         const mgr = new EditorManager('a.md');

--- a/crates/core/assets/js/managers/editor-manager.test.ts
+++ b/crates/core/assets/js/managers/editor-manager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EditorView } from '@codemirror/view';
 import { EditorManager } from './editor-manager';
 
 /**
@@ -25,6 +26,22 @@ function itemAt<T>(items: ArrayLike<T>, index: number): T {
     expect(item).toBeDefined();
     if (item === undefined) throw new Error(`Missing item at index ${index}`);
     return item;
+}
+
+function getEditorView(): EditorView {
+    const dom = document.querySelector<HTMLElement>('.cm-editor');
+    expect(dom).toBeTruthy();
+    if (!dom) throw new Error('CodeMirror editor not found');
+    const view = EditorView.findFromDOM(dom);
+    expect(view).toBeTruthy();
+    if (!view) throw new Error('CodeMirror view not found');
+    return view;
+}
+
+function replaceDocument(view: EditorView, content: string): void {
+    view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: content },
+    });
 }
 
 /** Stub jsdom-missing APIs the EditorManager touches. */
@@ -65,6 +82,9 @@ describe('EditorManager', () => {
     });
 
     afterEach(() => {
+        document.querySelectorAll<HTMLElement>('.cm-editor').forEach(dom => {
+            EditorView.findFromDOM(dom)?.destroy();
+        });
         logSpy.mockRestore();
         warnSpy.mockRestore();
         errorSpy.mockRestore();
@@ -98,8 +118,7 @@ describe('EditorManager', () => {
         await mgr.open();
 
         // Edit the buffer so save() has something to send.
-        const ta = document.querySelector<HTMLTextAreaElement>('.editor-textarea')!;
-        ta.value = '# changed';
+        replaceDocument(getEditorView(), '# changed');
         await mgr.save();
 
         // The first /api/save call (preview calls go to /api/preview).
@@ -124,14 +143,11 @@ describe('EditorManager', () => {
         seedOriginalMarkdown('hello');
         const mgr = new EditorManager('a.md');
         await mgr.open();
-        const ta = document.querySelector<HTMLTextAreaElement>('.editor-textarea')!;
-
-        ta.value = 'hello!';
-        ta.dispatchEvent(new Event('input'));
+        const view = getEditorView();
+        replaceDocument(view, 'hello!');
         expect(mgr.isDirty()).toBe(true);
 
-        ta.value = 'hello'; // back to baseline
-        ta.dispatchEvent(new Event('input'));
+        replaceDocument(view, 'hello'); // back to baseline
         expect(mgr.isDirty()).toBe(false);
     });
 
@@ -168,29 +184,29 @@ describe('EditorManager', () => {
         seedOriginalMarkdown(source);
         const mgr = new EditorManager('a.md');
         await mgr.open();
-        const ta = document.querySelector<HTMLTextAreaElement>('.editor-textarea')!;
-        ta.setSelectionRange(cursor, cursor);
+        const view = getEditorView();
+        view.dispatch({ selection: { anchor: cursor } });
 
         const enter = new KeyboardEvent('keydown', {
             key: 'Enter',
             bubbles: true,
             cancelable: true,
         });
-        ta.dispatchEvent(enter);
+        view.contentDOM.dispatchEvent(enter);
 
         expect(enter.defaultPrevented).toBe(true);
-        expect(ta.value).toBe(expected);
-        expect(ta.selectionStart).toBe(caret);
-        expect(ta.selectionEnd).toBe(caret);
+        expect(view.state.doc.toString()).toBe(expected);
+        expect(view.state.selection.main.anchor).toBe(caret);
+        expect(view.state.selection.main.head).toBe(caret);
         expect(mgr.isDirty()).toBe(true);
     });
 
-    it('modified Enter keeps the browser native behavior', async () => {
+    it('modified Enter keeps CodeMirror standard newline behavior', async () => {
         seedOriginalMarkdown('- item');
         const mgr = new EditorManager('a.md');
         await mgr.open();
-        const ta = document.querySelector<HTMLTextAreaElement>('.editor-textarea')!;
-        ta.setSelectionRange(ta.value.length, ta.value.length);
+        const view = getEditorView();
+        view.dispatch({ selection: { anchor: view.state.doc.length } });
 
         const enter = new KeyboardEvent('keydown', {
             key: 'Enter',
@@ -198,12 +214,11 @@ describe('EditorManager', () => {
             bubbles: true,
             cancelable: true,
         });
-        ta.dispatchEvent(enter);
+        view.contentDOM.dispatchEvent(enter);
 
-        expect(enter.defaultPrevented).toBe(false);
-        // jsdom does not apply the browser's native key action; unchanged text
-        // confirms that the list continuation handler stayed out of the way.
-        expect(ta.value).toBe('- item');
+        expect(enter.defaultPrevented).toBe(true);
+        expect(view.state.doc.toString()).toBe('- item\n');
+        expect(mgr.isDirty()).toBe(true);
     });
 
     it('layout toggle persists "full" to localStorage and loads it back', async () => {
@@ -237,9 +252,7 @@ describe('EditorManager', () => {
 
         const mgr = new EditorManager('a.md');
         await mgr.open();
-        const ta = document.querySelector<HTMLTextAreaElement>('.editor-textarea')!;
-        ta.value = 'changed';
-        ta.dispatchEvent(new Event('input'));
+        replaceDocument(getEditorView(), 'changed');
         expect(mgr.isDirty()).toBe(true);
 
         mgr.close();

--- a/crates/core/assets/js/managers/editor-manager.ts
+++ b/crates/core/assets/js/managers/editor-manager.ts
@@ -19,6 +19,30 @@ const LAYOUT_KEY = 'markon.editor.layout'; // 'split' | 'full'
  *  `.editor-line-number` (height: 22.4px = 14px font * 1.6 line-height). */
 const LINE_HEIGHT = 22.4;
 
+/**
+ * Return the marker that should be inserted after Enter at `cursor`, or null
+ * when the current line is not a Markdown list item. Matching only the text
+ * before the caret also handles splitting `1. existing text` immediately after
+ * the marker: the existing text moves behind the newly inserted `2. `.
+ */
+function markdownListContinuation(value: string, cursor: number): string | null {
+    const lineStart = value.lastIndexOf('\n', Math.max(0, cursor - 1)) + 1;
+    const beforeCursor = value.slice(lineStart, cursor);
+    const match = beforeCursor.match(/^([\t ]*)(?:(\d+)\.|([-+*]))(?:[\t ]+|$)(?:\[([ xX])\][\t ]+)?/);
+    if (!match) return null;
+
+    const indent = match[1] ?? '';
+    const ordered = match[2];
+    const bullet = match[3];
+    const task = match[4] !== undefined ? '[ ] ' : '';
+    if (ordered !== undefined) {
+        const next = Number.parseInt(ordered, 10) + 1;
+        if (!Number.isSafeInteger(next)) return null;
+        return `\n${indent}${next}. ${task}`;
+    }
+    return bullet === undefined ? null : `\n${indent}${bullet} ${task}`;
+}
+
 /** Layout mode for the split-pane editor. */
 export type EditorLayout = 'split' | 'full';
 
@@ -487,6 +511,39 @@ export class EditorManager {
             if ((e.ctrlKey || e.metaKey) && e.key === 's') {
                 e.preventDefault();
                 void this.save();
+                return;
+            }
+
+            // WebKit can leave the textarea selection at the pre-split offset
+            // when Return follows an otherwise empty Markdown list marker. A
+            // later keystroke then lands back on the previous line even though
+            // the mirrored highlight layer shows a new blank line (#60).
+            // Perform list continuation as one explicit edit so the value and
+            // caret move atomically. Modified Enter and IME composition keep
+            // their native behavior.
+            if (
+                e.key === 'Enter'
+                && !e.isComposing
+                && !e.shiftKey
+                && !e.ctrlKey
+                && !e.metaKey
+                && !e.altKey
+                && textarea.selectionStart === textarea.selectionEnd
+            ) {
+                const continuation = markdownListContinuation(
+                    textarea.value,
+                    textarea.selectionStart,
+                );
+                if (continuation !== null) {
+                    e.preventDefault();
+                    textarea.setRangeText(
+                        continuation,
+                        textarea.selectionStart,
+                        textarea.selectionEnd,
+                        'end',
+                    );
+                    textarea.dispatchEvent(new Event('input', { bubbles: true }));
+                }
             }
         });
 

--- a/crates/core/assets/js/managers/editor-manager.ts
+++ b/crates/core/assets/js/managers/editor-manager.ts
@@ -86,6 +86,8 @@ export class EditorManager {
     #baselineDoc: CodeMirrorText | null = null;
     #previewPane: HTMLElement | null = null;
     #previewDebounceId: ReturnType<typeof setTimeout> | null = null;
+    #previewAbort: AbortController | null = null;
+    #previewRevision = 0;
     #mathRendererPromise: Promise<void> | null = null;
     /** narrow-screen tab state */
     #activeTab: EditorTab = 'edit';
@@ -101,6 +103,12 @@ export class EditorManager {
     #onBack: (() => void) | null = null;
     /** Aborts the document/window listeners installed while the modal is open. */
     #listenerAbort: AbortController | null = null;
+    /** Coalesces callers while the lazy editor runtime is loading. */
+    #openingPromise: Promise<void> | null = null;
+    /** Prevents overlapping writes from completing out of order. */
+    #savePromise: Promise<void> | null = null;
+    /** Invalidates async work when an editor session closes or is superseded. */
+    #sessionId = 0;
 
     #listenerOptions(extra: AddEventListenerOptions = {}): AddEventListenerOptions {
         const signal = this.#listenerAbort?.signal;
@@ -117,17 +125,43 @@ export class EditorManager {
         return this.#isDirty;
     }
 
-    /** Is the editor modal currently open (DOM mounted)? */
+    /** Is the editor open or still loading its lazy runtime? */
     isOpen(): boolean {
-        return this.#editorModal !== null;
+        return this.#editorModal !== null || this.#openingPromise !== null;
     }
 
     /**
      * Open the editor.
      */
     async open(options: EditorOpenOptions = {}): Promise<void> {
+        if (this.#editorModal) {
+            this.#applyOpenTarget(options);
+            return;
+        }
+
+        const pendingOpen = this.#openingPromise;
+        if (pendingOpen) {
+            await pendingOpen;
+            if (this.#editorModal) this.#applyOpenTarget(options);
+            return;
+        }
+
+        const sessionId = ++this.#sessionId;
+        const openingPromise = this.#openSession(options, sessionId);
+        this.#openingPromise = openingPromise;
+        try {
+            await openingPromise;
+        } finally {
+            if (this.#openingPromise === openingPromise) {
+                this.#openingPromise = null;
+            }
+        }
+    }
+
+    async #openSession(options: EditorOpenOptions, sessionId: number): Promise<void> {
         this.#mode = options.mode ?? 'edit';
         this.#onBack = options.onBack ?? null;
+        this.#activeTab = 'edit';
 
         let content: string | null;
         if (this.#mode === 'export') {
@@ -137,6 +171,7 @@ export class EditorManager {
             this.#exportFileName = toMarkdownFilename(options.exportFileName);
         } else {
             content = await this.#fetchCurrentContent();
+            if (sessionId !== this.#sessionId) return;
             if (content === null) {
                 Logger.error('EditorManager', 'Failed to fetch file content');
                 alert('Failed to load file content. Please ensure edit feature is enabled.');
@@ -150,10 +185,12 @@ export class EditorManager {
         try {
             ({ createMarkdownEditor } = await import('../editor-codemirror'));
         } catch (error) {
+            if (sessionId !== this.#sessionId) return;
             Logger.error('EditorManager', 'Failed to load editor runtime:', error);
             alert('Failed to initialize the Markdown editor.');
             return;
         }
+        if (sessionId !== this.#sessionId) return;
 
         // Create editor UI
         this.#createEditorUI(content, createMarkdownEditor);
@@ -162,7 +199,12 @@ export class EditorManager {
         // full-screen editor.
         document.documentElement.classList.add('markon-scroll-lock');
 
-        // If line number provided, jump to that line
+        this.#applyOpenTarget(options);
+
+        Logger.log('EditorManager', `Editor opened (${this.#mode} mode)`);
+    }
+
+    #applyOpenTarget(options: EditorOpenOptions): void {
         if (options.line && options.line > 0) {
             this.#gotoLine(options.line);
         } else if (options.selectedText?.trim()) {
@@ -170,88 +212,136 @@ export class EditorManager {
         } else {
             this.#focusEditor();
         }
-
-        Logger.log('EditorManager', `Editor opened (${this.#mode} mode)`);
     }
 
     /**
      * Close the editor.
      */
     close(): void {
-        if (this.#editorModal) {
-            // In `edit` mode, unsaved changes risk data loss → confirm. In
-            // `export` mode the buffer is a throwaway copy, so just close.
-            if (this.#mode === 'edit' && this.#isDirty) {
-                const confirmClose = confirm('You have unsaved changes. Close anyway?');
-                if (!confirmClose) return;
+        if (!this.#editorModal) {
+            if (this.#openingPromise) {
+                ++this.#sessionId;
+                this.#openingPromise = null;
             }
-
-            // Clean up event listeners
-            document.removeEventListener('keydown', this.#handleEscapeKey);
-            if (this.#scrollSyncCleanup) {
-                this.#scrollSyncCleanup();
-                this.#scrollSyncCleanup = null;
-            }
-            // Remove the document/window listeners (divider drag, resize
-            // handlers) installed by the editor UI.
-            this.#listenerAbort?.abort();
-            this.#listenerAbort = null;
-            // Closing mid-drag aborts the mouseup listener that would have
-            // restored these — reset them here so the page stays usable.
-            document.body.style.cursor = '';
-            document.body.style.userSelect = '';
-
-            if (this.#previewDebounceId !== null) {
-                clearTimeout(this.#previewDebounceId);
-                this.#previewDebounceId = null;
-            }
-            const wasExport = this.#mode === 'export';
-            this.#editorView?.destroy();
-            this.#editorView = null;
-            this.#editorModal.remove();
-            this.#editorModal = null;
-            document.documentElement.classList.remove('markon-scroll-lock');
-            this.#saveButton = null;
-            this.#closeButton = null;
-            this.#previewPane = null;
-            this.#isDirty = false;
-            this.#baselineDoc = null;
-
-            // Edit mode reloads to re-render the just-saved file; export mode
-            // is a non-destructive overlay, so leave the page as-is.
-            if (!wasExport) {
-                window.location.reload();
-            }
-
-            Logger.log('EditorManager', 'Editor closed');
+            return;
         }
+
+        // In `edit` mode, unsaved changes risk data loss → confirm. In
+        // `export` mode the buffer is a throwaway copy, so just close.
+        if (this.#mode === 'edit' && this.#isDirty) {
+            const confirmClose = confirm('You have unsaved changes. Close anyway?');
+            if (!confirmClose) return;
+        }
+
+        ++this.#sessionId;
+        this.#openingPromise = null;
+        this.#savePromise = null;
+        this.#previewAbort?.abort();
+        this.#previewAbort = null;
+        ++this.#previewRevision;
+
+        // Clean up event listeners
+        document.removeEventListener('keydown', this.#handleEscapeKey);
+        if (this.#scrollSyncCleanup) {
+            this.#scrollSyncCleanup();
+            this.#scrollSyncCleanup = null;
+        }
+        // Remove the document/window listeners (divider drag, resize
+        // handlers) installed by the editor UI.
+        this.#listenerAbort?.abort();
+        this.#listenerAbort = null;
+        // Closing mid-drag aborts the mouseup listener that would have
+        // restored these — reset them here so the page stays usable.
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+
+        if (this.#previewDebounceId !== null) {
+            clearTimeout(this.#previewDebounceId);
+            this.#previewDebounceId = null;
+        }
+        const wasExport = this.#mode === 'export';
+        this.#editorView?.destroy();
+        this.#editorView = null;
+        this.#editorModal.remove();
+        this.#editorModal = null;
+        document.documentElement.classList.remove('markon-scroll-lock');
+        this.#saveButton = null;
+        this.#closeButton = null;
+        this.#previewPane = null;
+        this.#isDirty = false;
+        this.#baselineDoc = null;
+        this.#activeTab = 'edit';
+        this.#onBack = null;
+
+        // Edit mode reloads to re-render the just-saved file; export mode
+        // is a non-destructive overlay, so leave the page as-is.
+        if (!wasExport) {
+            window.location.reload();
+        }
+
+        Logger.log('EditorManager', 'Editor closed');
     }
 
     /**
      * Save the file.
      */
     async save(): Promise<void> {
-        if (!this.#editorView) return;
+        const editorView = this.#editorView;
+        if (!editorView) return;
 
-        const content = this.#editorView.state.doc.toString();
+        const savedDoc = editorView.state.doc;
+        const content = savedDoc.toString();
 
         // Export mode: "Save" means download a local .md, never hit the server.
         if (this.#mode === 'export') {
             downloadTextFile(this.#exportFileName, content);
             if (this.#saveButton) flashText(this.#saveButton, _t('web.export.downloaded'));
-            this.#baselineDoc = this.#editorView.state.doc;
+            this.#baselineDoc = savedDoc;
             this.#isDirty = false;
             return;
         }
 
-        const success = await this.#saveToServer(content);
+        const pendingSave = this.#savePromise;
+        if (pendingSave) {
+            await pendingSave;
+            return;
+        }
 
-        if (success) {
-            // Saved content becomes the new baseline; further edits compare against it
-            this.#baselineDoc = this.#editorView.state.doc;
-            this.#isDirty = false;
+        const sessionId = this.#sessionId;
+        const savePromise = this.#savePersistentDocument(content, savedDoc, sessionId);
+        this.#savePromise = savePromise;
+        try {
+            await savePromise;
+        } finally {
+            if (this.#savePromise === savePromise) {
+                this.#savePromise = null;
+            }
+        }
+    }
+
+    async #savePersistentDocument(
+        content: string,
+        savedDoc: CodeMirrorText,
+        sessionId: number,
+    ): Promise<void> {
+        this.#setSaving(true);
+        try {
+            const success = await this.#saveToServer(content);
+            if (!success || sessionId !== this.#sessionId) return;
+
+            const editorView = this.#editorView;
+            if (!editorView) return;
+
+            // Only the document sent to the server becomes the baseline. Edits
+            // made while the request was in flight must remain visibly dirty.
+            this.#baselineDoc = savedDoc;
+            this.#isDirty = !editorView.state.doc.eq(savedDoc);
             this.#updateSaveButtonState();
             this.#updateTitleDirtyIndicator();
+        } finally {
+            if (sessionId === this.#sessionId) {
+                this.#setSaving(false);
+            }
         }
     }
 
@@ -272,8 +362,6 @@ export class EditorManager {
 
     async #saveToServer(content: string): Promise<boolean> {
         try {
-            this.#setSaving(true);
-
             const workspaceId = Meta.get(CONFIG.META_TAGS.WORKSPACE_ID) ?? '';
             const token = Meta.get('save-token') ?? '';
             const body: EditorSaveRequest = {
@@ -312,8 +400,6 @@ export class EditorManager {
             const message = error instanceof Error ? error.message : String(error);
             alert(`Error saving file: ${message}`);
             return false;
-        } finally {
-            this.#setSaving(false);
         }
     }
 
@@ -376,9 +462,7 @@ export class EditorManager {
             <div class="editor-body">
                 <div class="editor-split">
                     <div class="editor-pane editor-pane-source">
-                        <div class="editor-container">
-                            <div class="editor-codemirror"></div>
-                        </div>
+                        <div class="editor-codemirror"></div>
                     </div>
                     <div class="editor-split-divider" title="Drag to resize"></div>
                     <div class="editor-pane editor-pane-preview">
@@ -720,6 +804,11 @@ export class EditorManager {
      * Schedule a preview pane update with debounce
      */
     #schedulePreviewUpdate(delay = 150): void {
+        // A document change makes any in-flight render stale immediately,
+        // even before the replacement request leaves the debounce window.
+        this.#previewAbort?.abort();
+        this.#previewAbort = null;
+        ++this.#previewRevision;
         if (this.#previewDebounceId !== null) {
             clearTimeout(this.#previewDebounceId);
         }
@@ -733,11 +822,18 @@ export class EditorManager {
      * Update the preview pane by calling /api/preview
      */
     async #updatePreview(): Promise<void> {
-        if (!this.#previewPane || !this.#editorView) return;
+        const previewPane = this.#previewPane;
+        const editorView = this.#editorView;
+        if (!previewPane || !editorView) return;
 
-        const content = this.#editorView.state.doc.toString();
+        const content = editorView.state.doc.toString();
         const workspaceId = Meta.get(CONFIG.META_TAGS.WORKSPACE_ID) ?? '';
         const token = Meta.get('preview-token') ?? '';
+        const sessionId = this.#sessionId;
+        const revision = ++this.#previewRevision;
+        this.#previewAbort?.abort();
+        const abort = new AbortController();
+        this.#previewAbort = abort;
         const body: EditorPreviewRequest = {
             workspace_id: workspaceId,
             content,
@@ -750,28 +846,39 @@ export class EditorManager {
                     'X-Markon-Token': token,
                 },
                 body: JSON.stringify(body),
+                signal: abort.signal,
             });
             if (!response.ok) return;
             const result = (await response.json()) as EditorPreviewResponse;
-            this.#previewPane.innerHTML = result.html;
+            if (
+                abort.signal.aborted
+                || revision !== this.#previewRevision
+                || sessionId !== this.#sessionId
+                || previewPane !== this.#previewPane
+            ) return;
+            previewPane.innerHTML = result.html;
 
             if (result.has_math) {
-                this.#renderMath();
+                this.#renderMath(previewPane, sessionId);
             }
         } catch (err) {
+            if (abort.signal.aborted) return;
             Logger.warn('EditorManager', 'Preview update failed:', err);
+        } finally {
+            if (this.#previewAbort === abort) {
+                this.#previewAbort = null;
+            }
         }
     }
 
-    #renderMath(): void {
-        if (!this.#previewPane) return;
+    #renderMath(previewPane: HTMLElement, sessionId: number): void {
         if (window.markonRenderMath) {
-            window.markonRenderMath(this.#previewPane);
+            window.markonRenderMath(previewPane);
             return;
         }
         void this.#loadMathRenderer().then(() => {
-            if (this.#previewPane) {
-                window.markonRenderMath?.(this.#previewPane);
+            if (sessionId === this.#sessionId && previewPane === this.#previewPane) {
+                window.markonRenderMath?.(previewPane);
             }
         });
     }

--- a/crates/core/assets/js/managers/editor-manager.ts
+++ b/crates/core/assets/js/managers/editor-manager.ts
@@ -1,8 +1,11 @@
 /**
  * EditorManager - Markdown source editor
- * Provides minimalist in-browser editing functionality with line numbers
+ * Provides a CodeMirror-powered in-browser Markdown editor
  */
 
+import type { Text as CodeMirrorText } from '@codemirror/state';
+import type { EditorView } from '@codemirror/view';
+import type { CreateMarkdownEditor } from '../editor-codemirror';
 import { CONFIG, i18n } from '../core/config';
 import { Logger } from '../core/utils';
 import { Meta } from '../services/dom';
@@ -15,33 +18,6 @@ const _t = (key: string, ...args: unknown[]): string => i18n.t(key, ...args);
 
 const SPLIT_KEY = 'markon.editor.split';
 const LAYOUT_KEY = 'markon.editor.layout'; // 'split' | 'full'
-/** Textarea line height in px — keep in sync with css/editor.css
- *  `.editor-line-number` (height: 22.4px = 14px font * 1.6 line-height). */
-const LINE_HEIGHT = 22.4;
-
-/**
- * Return the marker that should be inserted after Enter at `cursor`, or null
- * when the current line is not a Markdown list item. Matching only the text
- * before the caret also handles splitting `1. existing text` immediately after
- * the marker: the existing text moves behind the newly inserted `2. `.
- */
-function markdownListContinuation(value: string, cursor: number): string | null {
-    const lineStart = value.lastIndexOf('\n', Math.max(0, cursor - 1)) + 1;
-    const beforeCursor = value.slice(lineStart, cursor);
-    const match = beforeCursor.match(/^([\t ]*)(?:(\d+)\.|([-+*]))(?:[\t ]+|$)(?:\[([ xX])\][\t ]+)?/);
-    if (!match) return null;
-
-    const indent = match[1] ?? '';
-    const ordered = match[2];
-    const bullet = match[3];
-    const task = match[4] !== undefined ? '[ ] ' : '';
-    if (ordered !== undefined) {
-        const next = Number.parseInt(ordered, 10) + 1;
-        if (!Number.isSafeInteger(next)) return null;
-        return `\n${indent}${next}. ${task}`;
-    }
-    return bullet === undefined ? null : `\n${indent}${bullet} ${task}`;
-}
 
 /** Layout mode for the split-pane editor. */
 export type EditorLayout = 'split' | 'full';
@@ -102,14 +78,12 @@ export interface EditorPreviewResponse {
 export class EditorManager {
     #filePath: string;
     #editorModal: HTMLElement | null = null;
-    #textarea: HTMLTextAreaElement | null = null;
-    #lineNumbers: HTMLElement | null = null;
-    #highlightLayer: HTMLElement | null = null;
+    #editorView: EditorView | null = null;
     #saveButton: HTMLButtonElement | null = null;
     #closeButton: HTMLButtonElement | null = null;
     #isDirty = false;
-    /** last-saved (or initially loaded) content for dirty comparison */
-    #baselineContent = '';
+    /** Last-saved (or initially loaded) persistent document for dirty comparison. */
+    #baselineDoc: CodeMirrorText | null = null;
     #previewPane: HTMLElement | null = null;
     #previewDebounceId: ReturnType<typeof setTimeout> | null = null;
     #mathRendererPromise: Promise<void> | null = null;
@@ -170,13 +144,20 @@ export class EditorManager {
             }
         }
 
-        // Capture the loaded content as the dirty-comparison baseline
-        this.#baselineContent = content;
+        // CodeMirror is intentionally a lazy chunk so read-only page loads do
+        // not pay the editor engine's download/parse cost.
+        let createMarkdownEditor: CreateMarkdownEditor;
+        try {
+            ({ createMarkdownEditor } = await import('../editor-codemirror'));
+        } catch (error) {
+            Logger.error('EditorManager', 'Failed to load editor runtime:', error);
+            alert('Failed to initialize the Markdown editor.');
+            return;
+        }
 
         // Create editor UI
-        this.#createEditorUI(content);
+        this.#createEditorUI(content, createMarkdownEditor);
         this.#setupEventListeners();
-        this.#updateLineNumbers();
         // Lock the background page so the wheel can't scroll it behind the
         // full-screen editor.
         document.documentElement.classList.add('markon-scroll-lock');
@@ -225,16 +206,16 @@ export class EditorManager {
                 this.#previewDebounceId = null;
             }
             const wasExport = this.#mode === 'export';
+            this.#editorView?.destroy();
+            this.#editorView = null;
             this.#editorModal.remove();
             this.#editorModal = null;
             document.documentElement.classList.remove('markon-scroll-lock');
-            this.#textarea = null;
-            this.#lineNumbers = null;
             this.#saveButton = null;
             this.#closeButton = null;
             this.#previewPane = null;
             this.#isDirty = false;
-            this.#baselineContent = '';
+            this.#baselineDoc = null;
 
             // Edit mode reloads to re-render the just-saved file; export mode
             // is a non-destructive overlay, so leave the page as-is.
@@ -250,15 +231,15 @@ export class EditorManager {
      * Save the file.
      */
     async save(): Promise<void> {
-        if (!this.#textarea) return;
+        if (!this.#editorView) return;
 
-        const content = this.#textarea.value;
+        const content = this.#editorView.state.doc.toString();
 
         // Export mode: "Save" means download a local .md, never hit the server.
         if (this.#mode === 'export') {
             downloadTextFile(this.#exportFileName, content);
             if (this.#saveButton) flashText(this.#saveButton, _t('web.export.downloaded'));
-            this.#baselineContent = content;
+            this.#baselineDoc = this.#editorView.state.doc;
             this.#isDirty = false;
             return;
         }
@@ -267,7 +248,7 @@ export class EditorManager {
 
         if (success) {
             // Saved content becomes the new baseline; further edits compare against it
-            this.#baselineContent = content;
+            this.#baselineDoc = this.#editorView.state.doc;
             this.#isDirty = false;
             this.#updateSaveButtonState();
             this.#updateTitleDirtyIndicator();
@@ -350,7 +331,7 @@ export class EditorManager {
         }
     }
 
-    #createEditorUI(content: string): void {
+    #createEditorUI(content: string, createMarkdownEditor: CreateMarkdownEditor): void {
         const isExport = this.#mode === 'export';
         const fileName = isExport ? this.#exportFileName : this.#filePath;
         // Export mode swaps the file-bound Save for a Copy + Download pair and
@@ -396,11 +377,7 @@ export class EditorManager {
                 <div class="editor-split">
                     <div class="editor-pane editor-pane-source">
                         <div class="editor-container">
-                            <div class="editor-line-numbers"></div>
-                            <div class="editor-text-container">
-                                <pre class="editor-highlight-layer"><code></code></pre>
-                                <textarea class="editor-textarea" spellcheck="false"></textarea>
-                            </div>
+                            <div class="editor-codemirror"></div>
                         </div>
                     </div>
                     <div class="editor-split-divider" title="Drag to resize"></div>
@@ -413,16 +390,18 @@ export class EditorManager {
 
         document.body.appendChild(modal);
         this.#editorModal = modal;
-        this.#textarea = modal.querySelector<HTMLTextAreaElement>('.editor-textarea');
-        this.#lineNumbers = modal.querySelector<HTMLElement>('.editor-line-numbers');
-        this.#highlightLayer = modal.querySelector<HTMLElement>('.editor-highlight-layer code');
         this.#saveButton = modal.querySelector<HTMLButtonElement>('.editor-save-btn');
         this.#closeButton = modal.querySelector<HTMLButtonElement>('.editor-close');
         this.#previewPane = modal.querySelector<HTMLElement>('.editor-preview-content');
 
-        // Set textarea content (no HTML escaping needed for textarea.value)
-        if (this.#textarea) {
-            this.#textarea.value = content;
+        const editorHost = modal.querySelector<HTMLElement>('.editor-codemirror');
+        if (editorHost) {
+            this.#editorView = createMarkdownEditor(editorHost, content, {
+                onDocumentChanged: doc => this.#handleDocumentChanged(doc),
+                onSave: () => { void this.save(); },
+                onSelectionChanged: () => this.#refreshCopyLabel(),
+            });
+            this.#baselineDoc = this.#editorView.state.doc;
         }
 
         // Restore saved split position
@@ -436,9 +415,6 @@ export class EditorManager {
 
         // Setup narrow-screen tabs
         this.#setupTabs();
-
-        // Initialize syntax highlighting
-        this.#updateSyntaxHighlight();
 
         // Initial preview render
         this.#schedulePreviewUpdate(0);
@@ -461,33 +437,27 @@ export class EditorManager {
             void this.save();
         });
 
-        // Export-mode Copy button. Label + payload follow the textarea
+        // Export-mode Copy button. Label + payload follow the editor
         // selection: nothing selected → "Copy text" copies the whole buffer;
         // a selection → "Copy selection" copies just that range.
         const copyBtn = this.#editorModal?.querySelector<HTMLButtonElement>('.editor-copy-btn');
-        const hasSelection = (): boolean =>
-            !!this.#textarea && this.#textarea.selectionStart !== this.#textarea.selectionEnd;
-        const refreshCopyLabel = (): void => {
-            if (copyBtn) {
-                copyBtn.textContent = _t(hasSelection() ? 'web.export.copyselection' : 'web.export.copytext');
-            }
-        };
         copyBtn?.addEventListener('click', () => {
-            const ta = this.#textarea;
-            if (!ta || !copyBtn) return;
-            const content = hasSelection()
-                ? ta.value.slice(ta.selectionStart, ta.selectionEnd)
-                : ta.value;
+            const view = this.#editorView;
+            if (!view || !copyBtn) return;
+            const selection = view.state.selection.main;
+            const content = selection.empty
+                ? view.state.doc.toString()
+                : view.state.sliceDoc(selection.from, selection.to);
             void copyText(content).then(ok => {
                 copyBtn.textContent = _t(ok ? 'web.export.copied' : 'web.export.failed');
                 copyBtn.classList.add('is-flashing');
                 window.setTimeout(() => {
                     copyBtn.classList.remove('is-flashing');
-                    refreshCopyLabel();
+                    this.#refreshCopyLabel();
                 }, 1500);
             });
         });
-        refreshCopyLabel();
+        this.#refreshCopyLabel();
 
         // Export-mode Back button: close this overlay and return to the caller.
         this.#editorModal
@@ -498,91 +468,8 @@ export class EditorManager {
                 back?.();
             });
 
-        if (!this.#textarea) return;
-        const textarea = this.#textarea;
-
-        // Keep the Copy button label (Copy text / Copy selection) in sync with
-        // the current textarea selection.
-        ['select', 'keyup', 'mouseup'].forEach(ev =>
-            textarea.addEventListener(ev, refreshCopyLabel));
-
-        // Ctrl+S / Cmd+S to save
-        textarea.addEventListener('keydown', (e: KeyboardEvent) => {
-            if ((e.ctrlKey || e.metaKey) && e.key === 's') {
-                e.preventDefault();
-                void this.save();
-                return;
-            }
-
-            // WebKit can leave the textarea selection at the pre-split offset
-            // when Return follows an otherwise empty Markdown list marker. A
-            // later keystroke then lands back on the previous line even though
-            // the mirrored highlight layer shows a new blank line (#60).
-            // Perform list continuation as one explicit edit so the value and
-            // caret move atomically. Modified Enter and IME composition keep
-            // their native behavior.
-            if (
-                e.key === 'Enter'
-                && !e.isComposing
-                && !e.shiftKey
-                && !e.ctrlKey
-                && !e.metaKey
-                && !e.altKey
-                && textarea.selectionStart === textarea.selectionEnd
-            ) {
-                const continuation = markdownListContinuation(
-                    textarea.value,
-                    textarea.selectionStart,
-                );
-                if (continuation !== null) {
-                    e.preventDefault();
-                    textarea.setRangeText(
-                        continuation,
-                        textarea.selectionStart,
-                        textarea.selectionEnd,
-                        'end',
-                    );
-                    textarea.dispatchEvent(new Event('input', { bubbles: true }));
-                }
-            }
-        });
-
         // Esc to close
         document.addEventListener('keydown', this.#handleEscapeKey);
-
-        // Sync scroll between textarea, line numbers, and highlight layer
-        textarea.addEventListener('scroll', () => {
-            if (this.#lineNumbers) {
-                this.#lineNumbers.scrollTop = textarea.scrollTop;
-            }
-            if (this.#highlightLayer && this.#highlightLayer.parentElement) {
-                this.#highlightLayer.parentElement.scrollTop = textarea.scrollTop;
-                this.#highlightLayer.parentElement.scrollLeft = textarea.scrollLeft;
-            }
-        });
-
-        // Coalesce expensive updates to one per animation frame: typing-storm
-        // inputs fire 5-10× per frame, but we only need to repaint once.
-        let rafId: number | null = null;
-        let lastLineCount = -1;
-        textarea.addEventListener('input', () => {
-            // Compare against baseline so reverting edits clears the dirty state
-            this.#isDirty = textarea.value !== this.#baselineContent;
-            this.#updateSaveButtonState();
-            this.#updateTitleDirtyIndicator();
-            if (rafId !== null) return;
-            rafId = requestAnimationFrame(() => {
-                rafId = null;
-                const lines = textarea.value.split('\n').length;
-                if (lines !== lastLineCount) {
-                    lastLineCount = lines;
-                    this.#updateLineNumbers();
-                }
-                this.#updateSyntaxHighlight();
-            });
-            // Schedule preview update with debounce
-            this.#schedulePreviewUpdate(150);
-        });
     }
 
     #handleEscapeKey = (e: KeyboardEvent): void => {
@@ -591,11 +478,29 @@ export class EditorManager {
         }
     };
 
+    #handleDocumentChanged(doc: CodeMirrorText): void {
+        // Text.eq compares CodeMirror's persistent tree directly, avoiding a
+        // full document string allocation on every keystroke.
+        this.#isDirty = this.#baselineDoc === null || !doc.eq(this.#baselineDoc);
+        this.#updateSaveButtonState();
+        this.#updateTitleDirtyIndicator();
+        this.#schedulePreviewUpdate(150);
+    }
+
+    #refreshCopyLabel(): void {
+        const copyBtn = this.#editorModal?.querySelector<HTMLButtonElement>('.editor-copy-btn');
+        const selection = this.#editorView?.state.selection.main;
+        if (copyBtn) {
+            copyBtn.textContent = _t(selection && !selection.empty
+                ? 'web.export.copyselection'
+                : 'web.export.copytext');
+        }
+    }
+
     #focusEditor(): void {
-        if (this.#textarea) {
-            this.#textarea.focus();
-            // Move cursor to beginning
-            this.#textarea.setSelectionRange(0, 0);
+        if (this.#editorView) {
+            this.#editorView.focus();
+            this.#editorView.dispatch({ selection: { anchor: 0 } });
         }
     }
 
@@ -636,49 +541,28 @@ export class EditorManager {
         }
     }
 
-    #updateLineNumbers(): void {
-        if (!this.#textarea || !this.#lineNumbers) return;
-
-        // Numbering is sequential, so existing nodes never change — append
-        // the missing tail or trim the surplus instead of rebuilding all
-        // lines on every line-count change.
-        const lines = this.#textarea.value.split('\n').length;
-        const container = this.#lineNumbers;
-        while (container.childElementCount > lines) {
-            container.lastElementChild?.remove();
-        }
-        for (let num = container.childElementCount + 1; num <= lines; num++) {
-            const div = document.createElement('div');
-            div.className = 'editor-line-number';
-            div.textContent = String(num);
-            container.appendChild(div);
-        }
-    }
-
     /**
      * Find and select text in the editor with fuzzy matching for Markdown syntax
      */
     #selectText(searchText: string): void {
-        if (!this.#textarea) return;
+        if (!this.#editorView) return;
 
-        const content = this.#textarea.value;
+        const content = this.#editorView.state.doc.toString();
 
         // Try multiple search strategies
         const result = this.#findTextInSource(content, searchText);
 
         if (result !== -1) {
             // Found the text, select it
-            this.#textarea.focus();
-
             // Find the actual length in source (may include Markdown syntax)
             const actualLength = this.#findActualLength(content, result, searchText);
-            this.#textarea.setSelectionRange(result, result + actualLength);
+            this.#editorView.focus();
+            this.#editorView.dispatch({
+                selection: { anchor: result, head: result + actualLength },
+                scrollIntoView: true,
+            });
 
-            // Scroll to the selection
-            const beforeText = content.substring(0, result);
-            const lineNumber = beforeText.split('\n').length;
-            this.#scrollToLine(lineNumber);
-
+            const lineNumber = this.#editorView.state.doc.lineAt(result).number;
             Logger.log('EditorManager', `Selected text at index ${result}, line ${lineNumber}`);
         } else {
             // Text not found, just focus at the beginning
@@ -692,29 +576,17 @@ export class EditorManager {
      * Jump to a specific line number in the editor
      */
     #gotoLine(lineNum: number): void {
-        if (!this.#textarea) return;
-        const lines = this.#textarea.value.split('\n');
-        const targetLine = Math.min(lineNum, lines.length);
-        const pos = lines.slice(0, targetLine - 1).reduce((sum, l) => sum + l.length + 1, 0);
-        const endPos = pos + (lines[targetLine - 1] || '').length;
+        if (!this.#editorView) return;
+        const doc = this.#editorView.state.doc;
+        const targetLine = Math.min(lineNum, doc.lines);
+        const line = doc.line(targetLine);
 
-        this.#textarea.focus();
-        this.#textarea.setSelectionRange(pos, endPos);
-
-        this.#scrollToLine(targetLine);
+        this.#editorView.focus();
+        this.#editorView.dispatch({
+            selection: { anchor: line.from, head: line.to },
+            scrollIntoView: true,
+        });
         Logger.log('EditorManager', `Jumped to line ${targetLine}`);
-    }
-
-    /**
-     * Scroll the textarea so `lineNumber` sits near the top (2 lines of
-     * context above), keeping the line-number gutter in sync.
-     */
-    #scrollToLine(lineNumber: number): void {
-        if (!this.#textarea) return;
-        this.#textarea.scrollTop = Math.max(0, (lineNumber - 3) * LINE_HEIGHT);
-        if (this.#lineNumbers) {
-            this.#lineNumbers.scrollTop = this.#textarea.scrollTop;
-        }
     }
 
     /**
@@ -861,9 +733,9 @@ export class EditorManager {
      * Update the preview pane by calling /api/preview
      */
     async #updatePreview(): Promise<void> {
-        if (!this.#previewPane || !this.#textarea) return;
+        if (!this.#previewPane || !this.#editorView) return;
 
-        const content = this.#textarea.value;
+        const content = this.#editorView.state.doc.toString();
         const workspaceId = Meta.get(CONFIG.META_TAGS.WORKSPACE_ID) ?? '';
         const token = Meta.get('preview-token') ?? '';
         const body: EditorPreviewRequest = {
@@ -1035,6 +907,7 @@ export class EditorManager {
                     if (this.#activeTab === 'edit') {
                         sourcePane.style.display = 'flex';
                         previewPane.style.display = 'none';
+                        this.#editorView?.requestMeasure();
                     } else {
                         sourcePane.style.display = 'none';
                         previewPane.style.display = 'flex';
@@ -1085,6 +958,7 @@ export class EditorManager {
         this.#editorModal.querySelectorAll<HTMLElement>('.editor-layout-btn').forEach(btn => {
             btn.classList.toggle('active', btn.dataset['layout'] === mode);
         });
+        this.#editorView?.requestMeasure();
     }
 
     /**
@@ -1135,9 +1009,8 @@ export class EditorManager {
         // Only run in split mode on wide screens
         if (this.#layout !== 'split' || window.innerWidth <= 768) return;
 
-        // Source side scrolls on the textarea itself, not on .editor-pane-source
-        // (which is overflow:hidden). Preview side scrolls on .editor-pane-preview.
-        const sourceEl = this.#textarea;
+        // CodeMirror owns the source scroll container; preview scrolls on its pane.
+        const sourceEl = this.#editorView?.scrollDOM;
         const previewPane = this.#editorModal?.querySelector<HTMLElement>('.editor-pane-preview');
         if (!sourceEl || !previewPane) return;
 
@@ -1163,51 +1036,5 @@ export class EditorManager {
             sourceEl.removeEventListener('scroll', onSourceScroll);
             previewPane.removeEventListener('scroll', onPreviewScroll);
         };
-    }
-
-    /**
-     * Update syntax highlighting
-     */
-    #updateSyntaxHighlight(): void {
-        if (!this.#textarea || !this.#highlightLayer) return;
-
-        const text = this.#textarea.value;
-        const highlighted = this.#highlightMarkdown(text);
-        this.#highlightLayer.innerHTML = highlighted + '\n';
-    }
-
-    /**
-     * Simple Markdown syntax highlighting
-     */
-    #highlightMarkdown(text: string): string {
-        // Escape HTML first
-        let out = Text.escape(text);
-
-        // Apply syntax highlighting (order matters!)
-        out = out
-            // Headers (h1-h6)
-            .replace(/^(#{1,6})\s+(.+)$/gm, '<span class="md-header">$1</span> <span class="md-header-text">$2</span>')
-            // Bold **text** or __text__
-            .replace(/(\*\*|__)(.*?)\1/g, '<span class="md-bold">$1$2$1</span>')
-            // Italic *text* or _text_
-            .replace(/(\*|_)(.*?)\1/g, '<span class="md-italic">$1$2$1</span>')
-            // Inline code `code`
-            .replace(/`([^`]+)`/g, '<span class="md-code">`$1`</span>')
-            // Links [text](url)
-            .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<span class="md-link">[$1]($2)</span>')
-            // Images ![alt](url)
-            .replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<span class="md-image">![$1]($2)</span>')
-            // Blockquotes
-            .replace(/^(&gt;+)\s+(.+)$/gm, '<span class="md-quote">$1 $2</span>')
-            // Unordered lists
-            .replace(/^([\s]*)([-*+])\s+(.+)$/gm, '$1<span class="md-list">$2</span> $3')
-            // Ordered lists
-            .replace(/^([\s]*)(\d+\.)\s+(.+)$/gm, '$1<span class="md-list">$2</span> $3')
-            // Horizontal rules
-            .replace(/^([-*_]{3,})$/gm, '<span class="md-hr">$1</span>')
-            // Code blocks ```
-            .replace(/^```(\w*)$/gm, '<span class="md-code-fence">```$1</span>');
-
-        return out;
     }
 }

--- a/crates/core/assets/js/managers/export-manager.test.ts
+++ b/crates/core/assets/js/managers/export-manager.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EditorView } from '@codemirror/view';
 import { ExportManager } from './export-manager';
 import type { Annotation, AnnotationManager } from './annotation-manager';
 
@@ -43,11 +44,14 @@ describe('ExportManager', () => {
     });
 
     afterEach(() => {
+        document.querySelectorAll<HTMLElement>('.cm-editor').forEach(dom => {
+            EditorView.findFromDOM(dom)?.destroy();
+        });
         logSpy.mockRestore();
         vi.restoreAllMocks();
     });
 
-    it('opens the editable Markdown export directly without the selection step', () => {
+    it('opens the editable Markdown export directly without the selection step', async () => {
         const note = annotation('with-note', 'keep me');
         const plain = annotation('highlight-only', null);
         const manager = makeManager([note, plain]);
@@ -60,9 +64,13 @@ describe('ExportManager', () => {
         expect(exportManager.open()).toBe(true);
 
         expect(document.querySelector('.export-modal')).toBeNull();
-        expect(document.querySelector('.editor-modal-export')).toBeTruthy();
+        await vi.waitFor(() => {
+            expect(document.querySelector('.editor-modal-export')).toBeTruthy();
+        });
         expect(document.querySelector('.editor-back-btn')).toBeNull();
-        expect(document.querySelector<HTMLTextAreaElement>('.editor-textarea')?.value)
+        const editorDom = document.querySelector<HTMLElement>('.cm-editor');
+        expect(editorDom).toBeTruthy();
+        expect(editorDom ? EditorView.findFromDOM(editorDom)?.state.doc.toString() : null)
             .toBe('"quoted"\n> note\n');
 
         const format = manager.formatAsMarkdown as unknown as ReturnType<typeof vi.fn>;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,14 @@
     "vitest": "^4.1.4"
   },
   "dependencies": {
+    "@codemirror/commands": "^6.10.4",
+    "@codemirror/lang-markdown": "^6.5.1",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.6",
+    "@lezer/highlight": "^1.2.3",
     "@tanstack/virtual-core": "^3.17.0",
+    "codemirror": "^6.0.2",
     "katex": "^0.17.0"
   }
 }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -46,8 +46,11 @@ async function build() {
   const mainOpts = {
     ...shared,
     entryPoints: [resolve(srcDir, 'main.ts')],
-    outfile: resolve(outDir, 'main.js'),
+    outdir: outDir,
+    entryNames: '[name]',
+    chunkNames: 'chunks/[name]-[hash]',
     format: 'esm',
+    splitting: true,
     target: ['es2022'],
     plugins: watch ? [makeReloadPlugin('main')] : [],
   };
@@ -79,8 +82,11 @@ async function build() {
   const diffAnnotationsOpts = {
     ...shared,
     entryPoints: [resolve(srcDir, 'diff-annotations.ts')],
-    outfile: resolve(outDir, 'diff-annotations.js'),
+    outdir: outDir,
+    entryNames: '[name]',
+    chunkNames: 'chunks/[name]-[hash]',
     format: 'esm',
+    splitting: true,
     target: ['es2022'],
     // main.ts owns the dev reload EventSource.
   };

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -43,12 +43,19 @@ async function build() {
   await rm(outDir, { recursive: true, force: true });
   await mkdir(outDir, { recursive: true });
 
-  const mainOpts = {
+  // The document app and diff annotations both lazy-load the editor runtime.
+  // Build them together so esbuild owns each shared chunk exactly once.
+  const appEsmOpts = {
     ...shared,
-    entryPoints: [resolve(srcDir, 'main.ts')],
+    entryPoints: [
+      resolve(srcDir, 'main.ts'),
+      resolve(srcDir, 'diff-annotations.ts'),
+    ],
     outdir: outDir,
     entryNames: '[name]',
-    chunkNames: 'chunks/[name]-[hash]',
+    // Stable names prevent stale chunks from accumulating under --watch.
+    // Production keeps content hashes for cache-safe lazy loading.
+    chunkNames: watch ? 'chunks/[name]' : 'chunks/[name]-[hash]',
     format: 'esm',
     splitting: true,
     target: ['es2022'],
@@ -76,17 +83,6 @@ async function build() {
     entryPoints: [resolve(srcDir, 'markdown-diff.ts')],
     outfile: resolve(outDir, 'markdown-diff.js'),
     format: 'esm',
-    target: ['es2022'],
-    // main.ts owns the dev reload EventSource.
-  };
-  const diffAnnotationsOpts = {
-    ...shared,
-    entryPoints: [resolve(srcDir, 'diff-annotations.ts')],
-    outdir: outDir,
-    entryNames: '[name]',
-    chunkNames: 'chunks/[name]-[hash]',
-    format: 'esm',
-    splitting: true,
     target: ['es2022'],
     // main.ts owns the dev reload EventSource.
   };
@@ -204,11 +200,10 @@ async function build() {
   );
 
   if (watch) {
-    const ctxMain = await esbuild.context(mainOpts);
+    const ctxAppEsm = await esbuild.context(appEsmOpts);
     const ctxViewed = await esbuild.context(viewedOpts);
     const ctxWorkspaceDiff = await esbuild.context(workspaceDiffOpts);
     const ctxMarkdownDiff = await esbuild.context(markdownDiffOpts);
-    const ctxDiffAnnotations = await esbuild.context(diffAnnotationsOpts);
     const ctxDiffFileCreate = await esbuild.context(diffFileCreateOpts);
     const ctxDiffRefPicker = await esbuild.context(diffRefPickerOpts);
     const ctxDiffShortcuts = await esbuild.context(diffShortcutsOpts);
@@ -220,11 +215,10 @@ async function build() {
     const ctxGitRefs = await esbuild.context(gitRefsOpts);
     const ctxPageShortcuts = await esbuild.context(pageShortcutsOpts);
     const ctxMathRender = await esbuild.context(mathRenderOpts);
-    await ctxMain.watch();
+    await ctxAppEsm.watch();
     await ctxViewed.watch();
     await ctxWorkspaceDiff.watch();
     await ctxMarkdownDiff.watch();
-    await ctxDiffAnnotations.watch();
     await ctxDiffFileCreate.watch();
     await ctxDiffRefPicker.watch();
     await ctxDiffShortcuts.watch();
@@ -239,11 +233,10 @@ async function build() {
     console.log('[build] watching…');
   } else {
     await Promise.all([
-      esbuild.build(mainOpts),
+      esbuild.build(appEsmOpts),
       esbuild.build(viewedOpts),
       esbuild.build(workspaceDiffOpts),
       esbuild.build(markdownDiffOpts),
-      esbuild.build(diffAnnotationsOpts),
       esbuild.build(diffFileCreateOpts),
       esbuild.build(diffRefPickerOpts),
       esbuild.build(diffShortcutsOpts),


### PR DESCRIPTION
## What changed

- replace the transparent textarea plus mirrored regex highlighter with CodeMirror 6
- use CodeMirror's incremental Markdown parser, viewport rendering, line-number gutter, history, selection, search, bracket handling, and Markdown keymap
- preserve Markon's save, export, live preview, split layout, mobile tabs, selection jump, and proportional scroll-sync behavior
- keep Markon's token-based editor themes through a stable Markdown tag highlighter
- preserve Markon's marker-only list continuation requirement while delegating normal list editing to the CodeMirror Markdown keymap
- lazy-load the editor as an ESM chunk so read-only document views keep their existing main bundle size

## Root cause

The previous editor rendered a transparent textarea over a separately highlighted `pre` element. Every edit required whole-document regex highlighting and manual synchronization of text metrics, scrolling, line numbers, and selection. WebKit could leave the textarea selection at a stale offset after splitting a Markdown list marker, which caused #60.

CodeMirror owns the editable DOM, immutable document state, selection, IME and undo behavior, and incrementally parsed syntax ranges, eliminating the two-layer synchronization problem.

## User impact

- list continuation keeps the caret on the new line, including marker-only items
- large documents no longer trigger whole-document syntax-highlighting work on each keystroke
- users gain native CodeMirror history, search, multiple selections, bracket handling, folding, and Markdown-aware editing
- ordinary reading pages do not download the editor until Edit is opened (`main.js` remains about 210 KB; the editor is a separate lazy chunk)

## Validation

- `scripts/quality-gate.sh`
- 42 frontend test files / 467 tests
- full Rust test suite and Clippy
- production bundle build with shared lazy editor chunk
- browser verification of editor sizing, highlighting, and the exact #60 caret flow after preview debounce

Fixes #60
