### PR TITLE
fix: bound search index resource usage

### DIFF
--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{
+    collections::BTreeSet,
     path::{Path, PathBuf},
     sync::{Arc, Mutex, MutexGuard},
 };
@@ -13,7 +16,9 @@ use tantivy::{
 };
 use tantivy_jieba::JiebaTokenizer;
 
-use crate::workspace_fs::WorkspaceFs;
+use crate::workspace_fs::{WorkspaceFs, WorkspaceRelPath};
+
+const INDEX_DOCUMENT_BATCH_SIZE: usize = 64;
 
 /// Query string for `GET /_/{workspace_id}/search?q=…`.
 #[derive(Deserialize)]
@@ -40,35 +45,42 @@ pub struct SearchIndex {
     field_content: Field,
     start_dir: PathBuf,
     workspace_fs: Arc<WorkspaceFs>,
+    #[cfg(test)]
+    commit_count: AtomicUsize,
 }
 
 impl SearchIndex {
     /// Build an empty index whose schema/tokenizer/reader/writer are wired up
-    /// but which holds no documents yet. `start_dir` is the prefix that
-    /// `rel_path` strips, so stored `path` values stay relative and consistent
-    /// across [`Self::new`], [`Self::new_single_file`], and `update_file`.
+    /// but which holds no documents yet. Every stored path is supplied as a
+    /// normalized workspace route, keeping initial and incremental keys
+    /// consistent across directory and single-file scopes.
     fn empty(workspace_fs: Arc<WorkspaceFs>) -> tantivy::Result<Self> {
         // Build schema
         let mut schema_builder = Schema::builder();
 
-        let text_options = TextOptions::default()
-            .set_indexing_options(
-                TextFieldIndexing::default()
-                    .set_tokenizer("jieba")
-                    .set_index_option(IndexRecordOption::WithFreqsAndPositions),
-            )
-            .set_stored();
+        let indexed_text_options = TextOptions::default().set_indexing_options(
+            TextFieldIndexing::default()
+                .set_tokenizer("jieba")
+                .set_index_option(IndexRecordOption::WithFreqsAndPositions),
+        );
+        let stored_text_options = indexed_text_options.clone().set_stored();
 
         // Use STRING for path field - indexed but not tokenized, so we can delete by exact match
         let field_path = schema_builder.add_text_field("path", STRING | STORED);
-        let field_file_name = schema_builder.add_text_field("file_name", text_options.clone());
-        let field_title = schema_builder.add_text_field("title", text_options.clone());
-        let field_content = schema_builder.add_text_field("content", text_options);
+        let field_file_name =
+            schema_builder.add_text_field("file_name", stored_text_options.clone());
+        let field_title = schema_builder.add_text_field("title", stored_text_options);
+        // Full Markdown remains indexed for search, but is intentionally not
+        // STORED in Tantivy. Search snippets read at most the returned hits
+        // through WorkspaceFs, avoiding a second full-text copy in RAM.
+        let field_content = schema_builder.add_text_field("content", indexed_text_options);
 
         let schema = schema_builder.build();
 
-        // Create index in RAM
-        let index = Index::create_in_ram(schema);
+        // Keep the ephemeral index in an automatically-cleaned temporary
+        // MmapDirectory. Committed segments can be paged by the OS instead of
+        // forcing the entire workspace index to remain in process RAM.
+        let index = Index::create_from_tempdir(schema)?;
 
         // Register jieba + a LowerCaser so search is case-insensitive for Latin
         // text (CJK has no case, so jieba's output is unaffected). The same
@@ -93,6 +105,8 @@ impl SearchIndex {
             field_content,
             start_dir: workspace_fs.ambient_root().to_path_buf(),
             workspace_fs,
+            #[cfg(test)]
+            commit_count: AtomicUsize::new(0),
         })
     }
 
@@ -132,42 +146,64 @@ impl SearchIndex {
         })
     }
 
-    fn index_workspace(&self) -> tantivy::Result<()> {
-        use rayon::prelude::*;
+    fn commit(&self, writer: &mut IndexWriter) -> tantivy::Result<()> {
+        writer.commit()?;
+        #[cfg(test)]
+        self.commit_count.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
 
-        tracing::info!("indexing markdown files in {:?}", self.start_dir);
-
-        let paths: Vec<(String, PathBuf)> = self
-            .workspace_fs
+    fn workspace_markdown_files(&self) -> Vec<(WorkspaceRelPath, PathBuf)> {
+        self.workspace_fs
             .content_files(usize::MAX)
             .into_iter()
             .filter(|(rel, _)| rel.as_path().extension().is_some_and(|ext| ext == "md"))
-            .map(|(rel, path)| (rel.as_route(), path))
-            .collect();
+            .collect()
+    }
 
-        // Stage 1: parallel CPU-bound work. Each worker reads its file
-        // and builds the TantivyDocument without ever touching the
-        // writer lock, so rayon's parallelism is no longer serialised
-        // on a single mutex. Unreadable files are silently skipped, as
-        // before.
-        let docs: Vec<TantivyDocument> = paths
-            .par_iter()
-            .filter_map(|(rel, path)| {
-                let content = self.workspace_fs.read_content_to_string(rel).ok()?;
-                Some(self.build_document(path, &content))
-            })
-            .collect();
+    /// Read and tokenize a bounded group of files in parallel, then hand the
+    /// documents to the single Tantivy writer. Keeping only one small batch of
+    /// Markdown bodies alive avoids a workspace-sized memory spike during
+    /// initial indexing or an ignore-rule rebuild.
+    fn add_documents(
+        &self,
+        writer: &mut IndexWriter,
+        files: &[(WorkspaceRelPath, PathBuf)],
+    ) -> tantivy::Result<()> {
+        use rayon::prelude::*;
 
-        // Stage 2: serial write phase. Acquire the writer lock exactly
-        // once, batch every add_document, then commit. The guard is
-        // dropped at the end of the block, before reload(), so
-        // concurrent readers are not blocked any longer than needed.
-        {
-            let mut writer = self.writer()?;
+        for batch in files.chunks(INDEX_DOCUMENT_BATCH_SIZE) {
+            let docs: Vec<TantivyDocument> = batch
+                .par_iter()
+                .filter_map(|(rel, path)| {
+                    let relative_path = rel.as_route();
+                    let content = self
+                        .workspace_fs
+                        .read_content_to_string(&relative_path)
+                        .ok()?;
+                    Some(self.build_document(&relative_path, path, &content))
+                })
+                .collect();
             for doc in docs {
                 writer.add_document(doc)?;
             }
-            writer.commit()?;
+        }
+        Ok(())
+    }
+
+    fn index_workspace(&self) -> tantivy::Result<()> {
+        tracing::info!("indexing markdown files in {:?}", self.start_dir);
+
+        // Snapshot only paths up front; Markdown bodies are read later in
+        // bounded parallel batches so the entire workspace is never buffered.
+        let files = self.workspace_markdown_files();
+
+        // Acquire the writer once and commit the complete build once. The guard
+        // is dropped before reload(), so searches remain lock-free.
+        {
+            let mut writer = self.writer()?;
+            self.add_documents(&mut writer, &files)?;
+            self.commit(&mut writer)?;
         }
 
         self.reader.reload()?;
@@ -176,24 +212,20 @@ impl SearchIndex {
         Ok(())
     }
 
-    /// Path relative to `start_dir`, as stored in the `path` field and
-    /// used as the delete term for updates and removals.
-    fn rel_path(&self, path: &Path) -> String {
-        path.strip_prefix(&self.start_dir)
-            .unwrap_or(path)
-            .to_string_lossy()
-            .to_string()
+    fn replace_all(&self, files: &[(WorkspaceRelPath, PathBuf)]) -> tantivy::Result<()> {
+        {
+            let mut writer = self.writer()?;
+            writer.delete_all_documents()?;
+            self.add_documents(&mut writer, files)?;
+            self.commit(&mut writer)?;
+        }
+        self.reader.reload()?;
+        Ok(())
     }
 
-    /// Build a TantivyDocument for `path` with `content`. Pure CPU
-    /// work — does not touch the writer. Safe to call from rayon
-    /// workers in parallel.
-    fn build_document(&self, path: &Path, content: &str) -> TantivyDocument {
-        let relative_path = self
-            .workspace_fs
-            .route_for_path(path)
-            .unwrap_or_else(|| self.rel_path(path));
-
+    /// Build a TantivyDocument for an already-authorized route. Pure CPU work
+    /// — does not touch the writer and is safe to call from rayon workers.
+    fn build_document(&self, relative_path: &str, path: &Path, content: &str) -> TantivyDocument {
         let file_name = path
             .file_stem()
             .and_then(|s| s.to_str())
@@ -208,7 +240,7 @@ impl SearchIndex {
             .unwrap_or_else(|| file_name.clone());
 
         let mut doc = TantivyDocument::default();
-        doc.add_text(self.field_path, &relative_path);
+        doc.add_text(self.field_path, relative_path);
         doc.add_text(self.field_file_name, &file_name);
         doc.add_text(self.field_title, &title);
         doc.add_text(self.field_content, content);
@@ -251,8 +283,11 @@ impl SearchIndex {
                 .unwrap_or("")
                 .to_string();
 
-            let snippet = snippet_generator.snippet_from_doc(&retrieved_doc);
-            let snippet_html = snippet.to_html();
+            let snippet_html = self
+                .workspace_fs
+                .read_content_to_string(&file_path)
+                .map(|content| snippet_generator.snippet(&content).to_html())
+                .unwrap_or_default();
 
             results.push(SearchResult {
                 file_path,
@@ -265,55 +300,113 @@ impl SearchIndex {
         Ok(results)
     }
 
-    pub fn update_file(&self, path: &Path) -> tantivy::Result<()> {
-        let authorized = match self.workspace_fs.resolve_content_input(path) {
-            Ok(path) => path,
-            Err(_) => return Ok(()),
-        };
-        if authorized.extension().is_none_or(|ext| ext != "md") {
+    /// Reconcile a debounced batch of watcher paths against the filesystem's
+    /// current state. Every route is deleted first, then visible/readable
+    /// Markdown files are re-added, so creates, modifications, removals, and
+    /// both sides of renames converge correctly in one commit + reader reload.
+    ///
+    /// `content_files_for_routes` applies the same ignore policy as the initial
+    /// workspace walk. An ignored file is therefore deleted if an older build
+    /// or an earlier race ever placed it in the index.
+    pub(crate) fn reconcile_files(&self, paths: &[PathBuf]) -> tantivy::Result<()> {
+        let routes: BTreeSet<_> = paths
+            .iter()
+            .filter(|path| path.extension().is_some_and(|ext| ext == "md"))
+            .filter_map(|path| self.workspace_fs.lexical_route(path))
+            .collect();
+        if routes.is_empty() {
             return Ok(());
         }
 
-        let relative_path = self
-            .workspace_fs
-            .route_for_path(&authorized)
-            .unwrap_or_else(|| self.rel_path(&authorized));
-        let content = match self.workspace_fs.read_content_to_string(&relative_path) {
-            Ok(content) => content,
-            Err(_) => return Ok(()),
-        };
-        let doc = self.build_document(&authorized, &content);
-
-        // Delete and re-add in same transaction
-        {
-            let mut writer = self.writer()?;
-            let term = Term::from_field_text(self.field_path, &relative_path);
-            writer.delete_term(term);
-            writer.add_document(doc)?;
-            writer.commit()?;
+        let files = self.workspace_fs.content_files_for_routes(&routes);
+        let visible_routes: BTreeSet<_> = files.iter().map(|(route, _)| route.clone()).collect();
+        let searcher = self.reader.searcher();
+        let mut affected_routes = BTreeSet::new();
+        for route in &routes {
+            let term = Term::from_field_text(self.field_path, &route.as_route());
+            if visible_routes.contains(route) || searcher.doc_freq(&term)? > 0 {
+                affected_routes.insert(route.clone());
+            }
+        }
+        // Watchers observe ignored/hidden paths too. If none of those routes is
+        // visible or already indexed, avoid creating an empty Tantivy segment.
+        if affected_routes.is_empty() {
+            return Ok(());
         }
 
-        // Reload reader to see the changes
+        {
+            let mut writer = self.writer()?;
+            for route in &affected_routes {
+                writer.delete_term(Term::from_field_text(self.field_path, &route.as_route()));
+            }
+            self.add_documents(&mut writer, &files)?;
+            self.commit(&mut writer)?;
+        }
         self.reader.reload()?;
 
-        tracing::debug!("updated index: {}", relative_path);
+        tracing::debug!("reconciled {} search-index routes", routes.len());
         Ok(())
     }
 
+    /// Rebuild from the shared capability/ignore walk. Used only when an ignore
+    /// rule or directory topology changes, where per-file reconciliation cannot
+    /// determine every route that became visible or hidden.
+    pub(crate) fn rebuild(&self) -> tantivy::Result<()> {
+        let files = self.workspace_markdown_files();
+        self.replace_all(&files)?;
+        tracing::debug!("rebuilt search index");
+        Ok(())
+    }
+
+    /// Rebuild only when the visible Markdown route set has changed.
+    ///
+    /// Directory watchers also report topology changes inside paths excluded by
+    /// user `.gitignore` rules. Walking the authorized route set is cheap
+    /// compared with deleting and re-tokenizing the entire Tantivy index, and
+    /// lets those otherwise-empty batches remain true no-ops.
+    pub(crate) fn rebuild_if_routes_changed(&self) -> tantivy::Result<()> {
+        let files = self.workspace_markdown_files();
+        let searcher = self.reader.searcher();
+        let mut routes_match = searcher.num_docs() == files.len() as u64;
+        if routes_match {
+            for (route, _) in &files {
+                let term = Term::from_field_text(self.field_path, &route.as_route());
+                if searcher.doc_freq(&term)? != 1 {
+                    routes_match = false;
+                    break;
+                }
+            }
+        }
+        if routes_match {
+            tracing::debug!("search index route set unchanged; skipped rebuild");
+            return Ok(());
+        }
+
+        self.replace_all(&files)?;
+        tracing::debug!("rebuilt search index after route-set change");
+        Ok(())
+    }
+
+    pub fn update_file(&self, path: &Path) -> tantivy::Result<()> {
+        self.reconcile_files(&[path.to_path_buf()])
+    }
+
     pub fn delete_file(&self, path: &Path) -> tantivy::Result<()> {
-        let relative_path = self.rel_path(path);
+        let Some(route) = self.workspace_fs.lexical_route(path) else {
+            return Ok(());
+        };
 
         {
             let mut writer = self.writer()?;
-            let term = Term::from_field_text(self.field_path, &relative_path);
+            let term = Term::from_field_text(self.field_path, &route.as_route());
             writer.delete_term(term);
-            writer.commit()?;
+            self.commit(&mut writer)?;
         }
 
         // Reload reader to see the changes
         self.reader.reload()?;
 
-        tracing::debug!("removed from index: {}", relative_path);
+        tracing::debug!("removed from index: {}", route.as_route());
         Ok(())
     }
 }
@@ -495,6 +588,39 @@ mod tests {
     }
 
     #[test]
+    fn test_content_is_indexed_not_stored_and_snippet_reads_current_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("snippet.md");
+        fs::write(
+            &file_path,
+            "# Snippet\nneedle appears beside the original body.",
+        )
+        .unwrap();
+
+        let index = SearchIndex::new(temp_dir.path()).unwrap();
+        assert!(
+            !index
+                .index
+                .schema()
+                .get_field_entry(index.field_content)
+                .is_stored(),
+            "Markdown bodies must not be duplicated in Tantivy's stored fields"
+        );
+
+        // Leave the index deliberately stale while changing the file. The hit
+        // still comes from the indexed term, but its snippet must be generated
+        // from the current capability-scoped file content.
+        fs::write(
+            &file_path,
+            "# Snippet\nneedle appears beside the fresh on-disk body.",
+        )
+        .unwrap();
+        let results = index.search("needle", 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].snippet.contains("fresh on-disk body"));
+    }
+
+    #[test]
     fn test_ignore_non_markdown_files() {
         let temp_dir = TempDir::new().unwrap();
         let dir_path = temp_dir.path();
@@ -631,6 +757,165 @@ mod tests {
         assert!(results.is_empty());
     }
 
+    #[test]
+    fn test_incremental_update_respects_ignore_rules() {
+        let temp_dir = TempDir::new().unwrap();
+        let ignored_path = temp_dir.path().join("secret.md");
+        fs::create_dir(temp_dir.path().join(".git")).unwrap();
+        fs::write(temp_dir.path().join(".gitignore"), "secret.md\n").unwrap();
+        fs::write(&ignored_path, "# Secret\ninitial-private-token").unwrap();
+        fs::write(
+            temp_dir.path().join("visible.md"),
+            "# Visible\npublic-token",
+        )
+        .unwrap();
+
+        let index = SearchIndex::new(temp_dir.path()).unwrap();
+        assert!(index
+            .search("initial-private-token", 10)
+            .unwrap()
+            .is_empty());
+
+        // Regression for #49: the old watcher path bypassed the ignore walker
+        // and inserted an ignored file after its first modification.
+        fs::write(&ignored_path, "# Secret\nmodified-private-token").unwrap();
+        let commits_before = index.commit_count.load(Ordering::Relaxed);
+        index.update_file(&ignored_path).unwrap();
+        assert!(
+            index
+                .search("modified-private-token", 10)
+                .unwrap()
+                .is_empty(),
+            "an ignored file must remain absent after an incremental update"
+        );
+        assert_eq!(
+            index.commit_count.load(Ordering::Relaxed),
+            commits_before,
+            "an ignored file that was never indexed must not create an empty commit"
+        );
+        assert_eq!(index.search("public-token", 10).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_incremental_update_respects_ignored_and_hidden_parents() {
+        let temp_dir = TempDir::new().unwrap();
+        let ignored_dir = temp_dir.path().join("private");
+        let hidden_dir = temp_dir.path().join(".hidden");
+        fs::create_dir(temp_dir.path().join(".git")).unwrap();
+        fs::create_dir_all(&ignored_dir).unwrap();
+        fs::create_dir_all(&hidden_dir).unwrap();
+        fs::write(temp_dir.path().join(".gitignore"), "private/\n").unwrap();
+        let ignored = ignored_dir.join("ignored.md");
+        let hidden = hidden_dir.join("hidden.md");
+        fs::write(&ignored, "# Private\nignored-parent-token").unwrap();
+        fs::write(&hidden, "# Hidden\nhidden-parent-token").unwrap();
+
+        let index = SearchIndex::new(temp_dir.path()).unwrap();
+        index
+            .reconcile_files(&[ignored.clone(), hidden.clone()])
+            .unwrap();
+
+        assert!(index.search("ignored-parent-token", 10).unwrap().is_empty());
+        assert!(index.search("hidden-parent-token", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_rebuild_applies_new_ignore_rules() {
+        let temp_dir = TempDir::new().unwrap();
+        let secret_path = temp_dir.path().join("secret.md");
+        fs::write(&secret_path, "# Secret\nnewly-ignored-token").unwrap();
+        let index = SearchIndex::new(temp_dir.path()).unwrap();
+        assert_eq!(index.search("newly-ignored-token", 10).unwrap().len(), 1);
+
+        fs::create_dir(temp_dir.path().join(".git")).unwrap();
+        fs::write(temp_dir.path().join(".gitignore"), "secret.md\n").unwrap();
+        index.rebuild().unwrap();
+        assert!(
+            index.search("newly-ignored-token", 10).unwrap().is_empty(),
+            "changing ignore rules must remove documents already in the index"
+        );
+    }
+
+    #[test]
+    fn test_rebuild_if_routes_changed_skips_ignored_directory_churn() {
+        let temp_dir = TempDir::new().unwrap();
+        fs::create_dir(temp_dir.path().join(".git")).unwrap();
+        fs::write(temp_dir.path().join(".gitignore"), "generated/\n").unwrap();
+        fs::write(
+            temp_dir.path().join("visible.md"),
+            "# Visible\nstable-token",
+        )
+        .unwrap();
+        let index = SearchIndex::new(temp_dir.path()).unwrap();
+        let commits_before = index.commit_count.load(Ordering::Relaxed);
+
+        fs::create_dir_all(temp_dir.path().join("generated").join("nested")).unwrap();
+        fs::write(
+            temp_dir
+                .path()
+                .join("generated")
+                .join("nested")
+                .join("ignored.md"),
+            "# Ignored\nprivate-token",
+        )
+        .unwrap();
+        index.rebuild_if_routes_changed().unwrap();
+
+        assert_eq!(
+            index.commit_count.load(Ordering::Relaxed),
+            commits_before,
+            "ignored directory churn must not rebuild an unchanged index"
+        );
+        assert_eq!(index.search("stable-token", 10).unwrap().len(), 1);
+        assert!(index.search("private-token", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_reconcile_batch_deduplicates_paths_and_commits_once() {
+        let temp_dir = TempDir::new().unwrap();
+        let first = temp_dir.path().join("first.md");
+        let second = temp_dir.path().join("second.md");
+        fs::write(&first, "# First\nold-first-token").unwrap();
+        fs::write(&second, "# Second\nold-second-token").unwrap();
+        let index = SearchIndex::new(temp_dir.path()).unwrap();
+        let commits_before = index.commit_count.load(Ordering::Relaxed);
+
+        fs::write(&first, "# First\nnew-first-token").unwrap();
+        fs::write(&second, "# Second\nnew-second-token").unwrap();
+        index
+            .reconcile_files(&[first.clone(), first.clone(), second.clone()])
+            .unwrap();
+
+        assert_eq!(
+            index.commit_count.load(Ordering::Relaxed),
+            commits_before + 1,
+            "one watcher batch must produce exactly one Tantivy commit"
+        );
+        assert_eq!(index.search("new-first-token", 10).unwrap().len(), 1);
+        assert_eq!(index.search("new-second-token", 10).unwrap().len(), 1);
+        assert!(index.search("old-first-token", 10).unwrap().is_empty());
+        assert!(index.search("old-second-token", 10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_reconcile_batch_handles_rename_as_delete_plus_add() {
+        let temp_dir = TempDir::new().unwrap();
+        let old_path = temp_dir.path().join("old.md");
+        let new_path = temp_dir.path().join("new.md");
+        fs::write(&old_path, "# Rename\nrename-token").unwrap();
+        let index = SearchIndex::new(temp_dir.path()).unwrap();
+
+        fs::rename(&old_path, &new_path).unwrap();
+        index
+            .reconcile_files(&[old_path.clone(), new_path.clone()])
+            .unwrap();
+
+        let results = index.search("rename-token", 10).unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].file_path, "new.md");
+        assert_eq!(index.reader.searcher().num_docs(), 1);
+    }
+
     /// Stress the parallel parse -> serial write pipeline with enough
     /// files that rayon will fan out across multiple workers. Verifies
     /// every doc lands in the index and that content from arbitrary
@@ -640,7 +925,7 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let dir_path = temp_dir.path();
 
-        const N: usize = 50;
+        const N: usize = INDEX_DOCUMENT_BATCH_SIZE * 2 + 2;
         for i in 0..N {
             // Vary body size so workers spend different amounts of
             // CPU per file. Each file embeds its own unique marker
@@ -664,7 +949,7 @@ mod tests {
         // Probe a handful of unique markers to prove the content of
         // individual docs survived the parse -> write split, not just
         // the document count.
-        for i in [0usize, 7, 23, 49] {
+        for i in [0usize, 7, 65, N - 1] {
             let needle = format!("marker_token_{i}");
             let results = index.search(&needle, 10).unwrap();
             assert_eq!(
@@ -676,7 +961,7 @@ mod tests {
         }
 
         // Title-based search still works across the parallel pipeline.
-        let results = index.search("Doc", 100).unwrap();
+        let results = index.search("Doc", N + 1).unwrap();
         assert_eq!(results.len(), N);
     }
 

--- a/crates/core/src/workspace.rs
+++ b/crates/core/src/workspace.rs
@@ -4,10 +4,13 @@ use crate::markdown::extract_referenced_assets_for_file;
 use crate::search::SearchIndex;
 use crate::workspace_fs::WorkspaceFs;
 use arc_swap::ArcSwapOption;
-use notify::{EventKind, RecursiveMode, Watcher};
+use notify::{
+    event::{CreateKind, ModifyKind, RemoveKind},
+    EventKind, RecursiveMode, Watcher,
+};
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeSet, HashMap, HashSet},
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
@@ -20,6 +23,9 @@ const LIVE_RELOAD_EXTENSIONS: &[&str] = &[
     "md", "markdown", "png", "jpg", "jpeg", "gif", "webp", "avif", "svg", "css", "js",
 ];
 const LIVE_RELOAD_IGNORED_DIRS: &[&str] = &[".git", "node_modules", "target"];
+const WATCH_STOP_POLL: std::time::Duration = std::time::Duration::from_millis(500);
+const WATCH_DEBOUNCE: std::time::Duration = std::time::Duration::from_millis(250);
+const WATCH_MAX_BATCH_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct WorkspaceFlags {
@@ -563,15 +569,18 @@ fn refresh_allowed_assets(entry: &WorkspaceEntry, file_name: &str) {
     entry.fs.replace_assets(new_set);
 }
 
-/// Shared scaffold for the notify-based watchers below: spawn a thread that
-/// owns the channel and watcher, forward Ok events, and run `on_event` for
-/// each one. The thread exits (dropping the watcher) when the watch cannot
-/// be established, the channel closes, or `stopped` is set (workspace removed).
+/// Shared scaffold for the notify-based watchers below. Events are collected
+/// until 250ms of quiet, with a one-second maximum batch latency, before the
+/// callback runs once. This absorbs the duplicate/multi-stage events emitted by
+/// editors and prevents git operations from causing one search commit per path.
+///
+/// The thread exits (dropping the watcher) when the watch cannot be established,
+/// the channel closes, or `stopped` is set (workspace removed).
 fn spawn_watch_thread(
     root: PathBuf,
     mode: RecursiveMode,
     stopped: Arc<AtomicBool>,
-    mut on_event: impl FnMut(notify::Event) + Send + 'static,
+    mut on_events: impl FnMut(Vec<notify::Event>) + Send + 'static,
 ) {
     std::thread::spawn(move || {
         let (tx, rx) = std::sync::mpsc::channel();
@@ -588,17 +597,40 @@ fn spawn_watch_thread(
         // Poll with a timeout rather than a bare `recv()` so the thread wakes
         // periodically to observe `stopped` even when no filesystem events
         // arrive. A removed workspace would otherwise block here forever,
-        // leaking the OS thread and the in-RAM search index it pins.
+        // leaking the OS thread and the search index it pins.
         loop {
             if stopped.load(Ordering::Relaxed) {
                 return;
             }
-            match rx.recv_timeout(std::time::Duration::from_millis(500)) {
-                Ok(event) => {
+            match rx.recv_timeout(WATCH_STOP_POLL) {
+                Ok(first) => {
+                    let started = std::time::Instant::now();
+                    let mut events = vec![first];
+                    let mut disconnected = false;
+                    loop {
+                        if stopped.load(Ordering::Relaxed) {
+                            return;
+                        }
+                        let remaining = WATCH_MAX_BATCH_DELAY.saturating_sub(started.elapsed());
+                        if remaining.is_zero() {
+                            break;
+                        }
+                        match rx.recv_timeout(WATCH_DEBOUNCE.min(remaining)) {
+                            Ok(event) => events.push(event),
+                            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => break,
+                            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                                disconnected = true;
+                                break;
+                            }
+                        }
+                    }
                     if stopped.load(Ordering::Relaxed) {
                         return;
                     }
-                    on_event(event);
+                    on_events(events);
+                    if disconnected {
+                        return;
+                    }
                 }
                 Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
                 Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return,
@@ -622,51 +654,59 @@ fn spawn_single_file_watcher(root: PathBuf, entry: Arc<WorkspaceEntry>, file_nam
         root.clone(),
         RecursiveMode::NonRecursive,
         stopped,
-        move |event: notify::Event| {
-            for path in event.paths {
-                let Ok(rel) = path.strip_prefix(&root) else {
+        move |events: Vec<notify::Event>| {
+            let mut pinned_changed = false;
+            let mut broadcast_paths = BTreeSet::new();
+
+            for event in events {
+                let is_create_or_modify =
+                    matches!(event.kind, EventKind::Create(_) | EventKind::Modify(_));
+                let is_mutation = is_create_or_modify || matches!(event.kind, EventKind::Remove(_));
+                if !is_mutation {
                     continue;
-                };
-                let rel_str = rel.to_string_lossy().to_string();
-                let touched_pinned = path == target;
-                let touched_asset = entry.fs.is_asset(rel);
-                if !(touched_pinned || touched_asset) {
-                    continue;
                 }
-                let mut should_broadcast = false;
-                match event.kind {
-                    EventKind::Create(_) | EventKind::Modify(_) => {
-                        if touched_pinned {
-                            refresh_allowed_assets(&entry, &file_name);
-                            // Keep the file-scoped search index in sync. No-op
-                            // when search is disabled (no index loaded).
-                            if let Some(idx) = entry.search_index.load_full() {
-                                let _ = idx.update_file(&target);
-                            }
-                        }
-                        should_broadcast = true;
+                for path in event.paths {
+                    let Ok(rel) = path.strip_prefix(&root) else {
+                        continue;
+                    };
+                    let touched_pinned = path == target;
+                    let touched_asset = entry.fs.is_asset(rel);
+                    if !(touched_pinned || touched_asset) {
+                        continue;
                     }
-                    // Don't broadcast for Remove: the file just went away,
-                    // reloading would 404 the tab.
-                    EventKind::Remove(_) if touched_pinned => {
-                        entry.fs.clear_assets();
-                        if let Some(idx) = entry.search_index.load_full() {
-                            let _ = idx.delete_file(&target);
-                        }
+                    pinned_changed |= touched_pinned;
+                    if is_create_or_modify {
+                        broadcast_paths.insert(rel.to_string_lossy().to_string());
                     }
-                    _ => {}
                 }
-                if should_broadcast {
-                    let file_payload = serde_json::json!({
-                        "type": "file_changed",
-                        "workspace_id": entry.id,
-                        "path": rel_str,
-                    })
-                    .to_string();
-                    let _ = entry.events_tx.send(WorkspaceEvent::Workspace {
-                        payload: file_payload,
-                    });
+            }
+
+            if pinned_changed {
+                if target.is_file() {
+                    refresh_allowed_assets(&entry, &file_name);
+                } else {
+                    // Don't broadcast for a final removal: the file just went
+                    // away and reloading would 404 the tab.
+                    entry.fs.clear_assets();
+                    broadcast_paths.remove(&file_name);
                 }
+                if let Some(idx) = entry.search_index.load_full() {
+                    if let Err(error) = idx.reconcile_files(std::slice::from_ref(&target)) {
+                        tracing::warn!("single-file search index update failed: {error}");
+                    }
+                }
+            }
+
+            for rel_str in broadcast_paths {
+                let file_payload = serde_json::json!({
+                    "type": "file_changed",
+                    "workspace_id": entry.id,
+                    "path": rel_str,
+                })
+                .to_string();
+                let _ = entry.events_tx.send(WorkspaceEvent::Workspace {
+                    payload: file_payload,
+                });
             }
         },
     );
@@ -686,34 +726,170 @@ fn spawn_directory_watcher(root: PathBuf, entry: Arc<WorkspaceEntry>) {
         root.clone(),
         RecursiveMode::Recursive,
         stopped,
-        move |event: notify::Event| {
-            let event_kind = event.kind;
-            for path in event.paths {
-                match &event_kind {
-                    EventKind::Create(_) | EventKind::Modify(_) => {
-                        if let Some(idx) = entry.search_index.load_full() {
-                            let _ = idx.update_file(&path);
-                        }
+        move |events: Vec<notify::Event>| {
+            let search_changes = coalesce_search_changes(&root, &events);
+            if let Some(idx) = entry.search_index.load_full() {
+                let result = if search_changes.rebuild {
+                    if search_changes.paths.is_empty() {
+                        idx.rebuild_if_routes_changed()
+                    } else {
+                        idx.rebuild()
                     }
-                    EventKind::Remove(_) => {
-                        if let Some(idx) = entry.search_index.load_full() {
-                            let _ = idx.delete_file(&path);
-                        }
+                } else {
+                    idx.reconcile_files(&search_changes.paths)
+                };
+                if let Err(error) = result {
+                    tracing::warn!("directory search index update failed: {error}");
+                }
+            }
+
+            let mut broadcast_paths = BTreeSet::new();
+            for event in events {
+                if !matches!(
+                    event.kind,
+                    EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+                ) {
+                    continue;
+                }
+                for path in event.paths {
+                    if let Some(rel_str) = directory_live_reload_path(&root, &path) {
+                        broadcast_paths.insert(rel_str);
                     }
-                    _ => continue,
                 }
-                if let Some(rel_str) = directory_live_reload_path(&root, &path) {
-                    let payload = serde_json::json!({
-                        "type": "file_changed",
-                        "workspace_id": entry.id,
-                        "path": rel_str,
-                    })
-                    .to_string();
-                    let _ = entry.events_tx.send(WorkspaceEvent::Workspace { payload });
-                }
+            }
+            for rel_str in broadcast_paths {
+                let payload = serde_json::json!({
+                    "type": "file_changed",
+                    "workspace_id": entry.id,
+                    "path": rel_str,
+                })
+                .to_string();
+                let _ = entry.events_tx.send(WorkspaceEvent::Workspace { payload });
             }
         },
     );
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct SearchChangeBatch {
+    paths: Vec<PathBuf>,
+    rebuild: bool,
+}
+
+/// Collapse notify's often-repeated events into the smallest search operation.
+/// Ordinary Markdown paths are reconciled once. Ignore-rule or directory
+/// topology changes require a full rebuild because they may affect paths that
+/// did not themselves emit an event.
+fn coalesce_search_changes(root: &Path, events: &[notify::Event]) -> SearchChangeBatch {
+    let mut paths = BTreeSet::new();
+    let mut rebuild = false;
+
+    for event in events {
+        if event.need_rescan() {
+            rebuild = true;
+        }
+        if !matches!(
+            event.kind,
+            EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_)
+        ) {
+            continue;
+        }
+        let relevant_paths: Vec<_> = event
+            .paths
+            .iter()
+            .filter(|path| !is_search_event_path_ignored(root, path))
+            .collect();
+        if relevant_paths.is_empty() {
+            continue;
+        }
+
+        let explicit_directory_event = matches!(
+            event.kind,
+            EventKind::Create(CreateKind::Folder) | EventKind::Remove(RemoveKind::Folder)
+        );
+        let created_directory = matches!(
+            event.kind,
+            EventKind::Create(CreateKind::Any | CreateKind::Other)
+        ) && relevant_paths.iter().any(|path| path.is_dir());
+        // Some backends cannot identify a removed entry's type. Extensionless
+        // removals may be directories, and a rebuild is the only way to remove
+        // every indexed descendant after the path no longer exists.
+        let ambiguous_removed_directory =
+            matches!(
+                event.kind,
+                EventKind::Remove(RemoveKind::Any | RemoveKind::Other)
+            ) && relevant_paths.iter().any(|path| path.extension().is_none());
+        // The old side of a renamed directory no longer exists, so `is_dir`
+        // alone cannot identify it. Extensionless rename paths conservatively
+        // request a rebuild; Markdown file renames stay on the batch fast path.
+        let renamed_directory = matches!(event.kind, EventKind::Modify(ModifyKind::Name(_)))
+            && relevant_paths.iter().any(|path| path.extension().is_none());
+        rebuild |= explicit_directory_event
+            || created_directory
+            || ambiguous_removed_directory
+            || renamed_directory;
+
+        for path in relevant_paths {
+            let rel = path.strip_prefix(root).unwrap_or(path);
+            if is_search_ignore_file(rel) {
+                rebuild = true;
+            }
+            if path.extension().is_some_and(|ext| ext == "md") {
+                paths.insert(path.clone());
+            }
+        }
+    }
+
+    SearchChangeBatch {
+        paths: paths.into_iter().collect(),
+        rebuild,
+    }
+}
+
+/// notify watches the raw tree, while search uses the standard ignore walker.
+/// Drop paths that the shared walker excludes intrinsically before they can
+/// trigger an empty commit or a full rebuild. Explicit ignore-rule files are
+/// retained because changing them can alter visibility elsewhere.
+fn is_search_event_path_ignored(root: &Path, path: &Path) -> bool {
+    let rel = path.strip_prefix(root).unwrap_or(path);
+    let components: Vec<_> = rel.components().map(|part| part.as_os_str()).collect();
+    let retained_rule_suffix = if components.last().is_some_and(|name| {
+        *name == std::ffi::OsStr::new(".gitignore") || *name == std::ffi::OsStr::new(".ignore")
+    }) {
+        1
+    } else if components.ends_with(&[
+        std::ffi::OsStr::new(".git"),
+        std::ffi::OsStr::new("info"),
+        std::ffi::OsStr::new("exclude"),
+    ]) {
+        3
+    } else {
+        0
+    };
+    components[..components.len().saturating_sub(retained_rule_suffix)]
+        .iter()
+        .any(|component| {
+            let name = component.to_string_lossy();
+            name.starts_with('.')
+                || LIVE_RELOAD_IGNORED_DIRS
+                    .iter()
+                    .any(|ignored| name.eq_ignore_ascii_case(ignored))
+        })
+}
+
+fn is_search_ignore_file(rel: &Path) -> bool {
+    if rel
+        .file_name()
+        .is_some_and(|name| name == ".gitignore" || name == ".ignore")
+    {
+        return true;
+    }
+    let components: Vec<_> = rel.components().map(|part| part.as_os_str()).collect();
+    components.ends_with(&[
+        std::ffi::OsStr::new(".git"),
+        std::ffi::OsStr::new("info"),
+        std::ffi::OsStr::new("exclude"),
+    ])
 }
 
 fn directory_live_reload_path(root: &Path, path: &Path) -> Option<String> {
@@ -987,6 +1163,76 @@ mod tests {
         assert!(directory_live_reload_path(root, &root.join("target").join("x.css")).is_none());
         assert!(directory_live_reload_path(root, &root.join("README")).is_none());
         assert!(directory_live_reload_path(root, &root.join("notes.txt")).is_none());
+    }
+
+    #[test]
+    fn search_change_batch_deduplicates_markdown_paths() {
+        let root = Path::new("/repo");
+        let first = root.join("docs").join("a.md");
+        let second = root.join("docs").join("b.md");
+        let modify_kind = EventKind::Modify(ModifyKind::Data(notify::event::DataChange::Content));
+        let events = vec![
+            notify::Event::new(modify_kind).add_path(first.clone()),
+            notify::Event::new(modify_kind).add_path(first.clone()),
+            notify::Event::new(EventKind::Create(CreateKind::File)).add_path(second.clone()),
+        ];
+
+        let batch = coalesce_search_changes(root, &events);
+        assert!(!batch.rebuild);
+        assert_eq!(batch.paths, vec![first, second]);
+    }
+
+    #[test]
+    fn search_change_batch_rebuilds_for_ignore_and_directory_changes() {
+        let root = Path::new("/repo");
+        let ignore_event = notify::Event::new(EventKind::Modify(ModifyKind::Data(
+            notify::event::DataChange::Content,
+        )))
+        .add_path(root.join("docs").join(".gitignore"));
+        let directory_event = notify::Event::new(EventKind::Remove(RemoveKind::Folder))
+            .add_path(root.join("old-docs"));
+
+        assert!(coalesce_search_changes(root, &[ignore_event]).rebuild);
+        assert!(coalesce_search_changes(root, &[directory_event]).rebuild);
+        assert!(is_search_ignore_file(Path::new(".git/info/exclude")));
+        assert!(!is_search_ignore_file(Path::new(".git/index")));
+    }
+
+    #[test]
+    fn search_change_batch_drops_intrinsically_ignored_paths() {
+        let root = Path::new("/repo");
+        let ignored_file = root.join("node_modules").join("pkg").join("README.md");
+        let hidden_file = root.join(".cache").join("generated.md");
+        let ignored_directory = root.join("target").join("generated-docs");
+        let events = vec![
+            notify::Event::new(EventKind::Modify(ModifyKind::Data(
+                notify::event::DataChange::Content,
+            )))
+            .add_path(ignored_file),
+            notify::Event::new(EventKind::Create(CreateKind::File)).add_path(hidden_file),
+            notify::Event::new(EventKind::Create(CreateKind::Folder)).add_path(ignored_directory),
+        ];
+
+        assert_eq!(
+            coalesce_search_changes(root, &events),
+            SearchChangeBatch::default()
+        );
+        assert!(is_search_event_path_ignored(
+            root,
+            &root.join(".hidden").join("note.md")
+        ));
+        assert!(!is_search_event_path_ignored(
+            root,
+            &root.join("docs").join(".gitignore")
+        ));
+        assert!(!is_search_event_path_ignored(
+            root,
+            &root.join(".git").join("info").join("exclude")
+        ));
+        assert!(is_search_event_path_ignored(
+            root,
+            &root.join("node_modules").join("pkg").join(".gitignore")
+        ));
     }
 
     /// Regression for #32: the workspace list must be deterministically ordered

--- a/crates/core/src/workspace_fs.rs
+++ b/crates/core/src/workspace_fs.rs
@@ -7,7 +7,7 @@
 
 use cap_std::ambient_authority;
 use cap_std::fs::Dir;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
@@ -284,6 +284,86 @@ impl WorkspaceFs {
                 .into_iter()
                 .collect(),
             WorkspaceScope::Directory => self.walk_authorized(limit, |_| true),
+        }
+    }
+
+    /// Convert a watcher-supplied path into a lexical workspace route without
+    /// requiring the target to still exist. This is deliberately separate from
+    /// [`Self::route_for_path`], which canonicalizes and therefore cannot
+    /// represent a path after a remove/rename event.
+    pub(crate) fn lexical_route(&self, path: &Path) -> Option<WorkspaceRelPath> {
+        let rel = if path.is_absolute() {
+            path.strip_prefix(&self.ambient_root)
+                .or_else(|_| path.strip_prefix(&self.canonical_root))
+                .ok()?
+        } else {
+            path
+        };
+        WorkspaceRelPath::parse(rel).ok()
+    }
+
+    /// Resolve only the requested routes that are currently visible under the
+    /// same standard ignore rules as [`Self::content_files`].
+    ///
+    /// Directory workspaces start at the workspace root so ignored/hidden
+    /// parent directories are evaluated exactly like the initial full walk.
+    /// A filter prunes every branch that is not an ancestor of a candidate, so
+    /// an incremental save does not rescan unrelated workspace subtrees.
+    pub(crate) fn content_files_for_routes(
+        &self,
+        routes: &BTreeSet<WorkspaceRelPath>,
+    ) -> Vec<(WorkspaceRelPath, PathBuf)> {
+        match &self.scope {
+            WorkspaceScope::SingleFile { document, .. } => {
+                if !routes.contains(&document.route) {
+                    return Vec::new();
+                }
+                self.resolve_scoped(&document.route, &document.target)
+                    .ok()
+                    .filter(|abs| abs.is_file())
+                    .map(|abs| (document.route.clone(), abs))
+                    .into_iter()
+                    .collect()
+            }
+            WorkspaceScope::Directory => {
+                let candidates: BTreeSet<PathBuf> = routes
+                    .iter()
+                    .map(|route| self.canonical_root.join(route.as_path()))
+                    .filter(|path| path.is_file())
+                    .collect();
+                if candidates.is_empty() {
+                    return Vec::new();
+                }
+
+                let root = self.canonical_root.clone();
+                let mut relevant_paths = BTreeSet::new();
+                for candidate in &candidates {
+                    for ancestor in candidate.ancestors() {
+                        if !ancestor.starts_with(&root) {
+                            break;
+                        }
+                        relevant_paths.insert(ancestor.to_path_buf());
+                        if ancestor == root {
+                            break;
+                        }
+                    }
+                }
+                let mut walker = default_walker(&root);
+                walker.filter_entry(move |entry| relevant_paths.contains(entry.path()));
+                walker
+                    .build()
+                    .filter_map(Result::ok)
+                    .filter(|entry| entry.path().is_file())
+                    .filter(|entry| candidates.contains(entry.path()))
+                    .filter_map(|entry| {
+                        let rel = entry.path().strip_prefix(&self.canonical_root).ok()?;
+                        let route = WorkspaceRelPath::parse(rel).ok()?;
+                        let target = self.canonicalize_rel(&route).ok()?;
+                        let absolute = self.absolute(&target);
+                        absolute.is_file().then_some((route, absolute))
+                    })
+                    .collect()
+            }
         }
     }
 


### PR DESCRIPTION
## What changed

- Move each ephemeral Tantivy index from `RamDirectory` to an auto-cleaned mmap-backed temporary directory.
- Stop storing full Markdown bodies in Tantivy; generate snippets on demand through the workspace capability layer.
- Read initial/rebuild documents in bounded batches instead of buffering the full workspace body set.
- Debounce watcher events (250 ms quiet window, 1 s maximum latency), deduplicate paths, and commit/reload once per batch.
- Reconcile creates, edits, deletes, renames, ignore-rule changes, and directory topology changes against the same visibility rules used by the initial index.
- Drop intrinsically ignored watcher paths and skip rebuilds when churn inside a user-ignored directory leaves the visible route set unchanged.

## Root cause and impact

The old index duplicated every Markdown body inside an in-memory Tantivy index, while the watcher committed and reloaded once per filesystem event. Large workspaces and Git operations therefore caused avoidable RSS growth, segment churn, and CPU spikes. The new path keeps the same search API and result visibility while bounding transient body memory and collapsing event storms.

## Validation

- `cargo build --workspace`
- `cargo test --workspace` (320 core unit tests, 13 search integration tests, plus CLI/GUI suites)
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npm test` (478 tests)
- `npm run typecheck`
- `npm run lint`
- Runtime smoke check against a workspace containing `node_modules`: ignored README content was absent from search while visible Markdown remained searchable.

Closes #49
