### PR TITLE
fix: bootstrap admin session on final page

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -453,6 +453,17 @@ fn resolve_workspace_list_base(
     }
 }
 
+fn rehome_admin_bootstrap_url(base: &str, redirect: &str, issued_url: &str) -> String {
+    let initial_route = redirect
+        .split_once('#')
+        .map_or(redirect, |(route, _fragment)| route);
+    let target = server::build_workspace_url(base, initial_route);
+    match issued_url.split_once('#').map(|(_, fragment)| fragment) {
+        Some(fragment) if !fragment.is_empty() => format!("{target}#{fragment}"),
+        _ => target,
+    }
+}
+
 fn print_workspace_access_summary(summary: &WorkspaceAccessSummary) {
     let colors = CliColors::detect();
     println!(
@@ -770,17 +781,9 @@ async fn forward_to_running_server(
                         let browser_url = if base_option == "local" {
                             boot_url
                         } else {
-                            // Re-home the bootstrap onto the requested custom
-                            // base, preserving its nonce fragment.
-                            let fragment =
-                                boot_url.split_once('#').map(|(_, frag)| frag).unwrap_or("");
-                            let bootstrap =
-                                server::build_workspace_url(base_option, "/_/admin/bootstrap");
-                            if fragment.is_empty() {
-                                bootstrap
-                            } else {
-                                format!("{bootstrap}#{fragment}")
-                            }
+                            // Re-home the final target onto the requested custom
+                            // base while preserving the one-time fragment.
+                            rehome_admin_bootstrap_url(base_option, &redirect, &boot_url)
                         };
                         if let Err(e) = open::that(&browser_url) {
                             tracing::warn!("best-effort browser open failed: {e}");
@@ -1296,6 +1299,26 @@ mod tests {
                 command: AdminCommands::Code
             })
         ));
+    }
+
+    #[test]
+    fn custom_base_admin_bootstrap_still_starts_at_final_target() {
+        assert_eq!(
+            rehome_admin_bootstrap_url(
+                "https://md.example.com/root/",
+                "/workspace/file.md?mode=preview",
+                "http://127.0.0.1:6419/workspace/file.md?mode=preview#bootstrap_nonce=abc"
+            ),
+            "https://md.example.com/root/workspace/file.md?mode=preview#bootstrap_nonce=abc"
+        );
+        assert_eq!(
+            rehome_admin_bootstrap_url(
+                "https://md.example.com",
+                "/workspace/file.md#heading",
+                "http://127.0.0.1:6419/workspace/file.md#bootstrap_nonce=abc"
+            ),
+            "https://md.example.com/workspace/file.md#bootstrap_nonce=abc"
+        );
     }
 
     #[test]

--- a/crates/core/assets/js/admin-session-boot.test.ts
+++ b/crates/core/assets/js/admin-session-boot.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    bootstrapNonce,
+    exchangeAdminNonce,
+    runAdminSessionBootstrap,
+    type AdminSessionBootstrapRuntime,
+} from './admin-session-boot';
+
+function runtime(
+    location: AdminSessionBootstrapRuntime['location'],
+    exchange: AdminSessionBootstrapRuntime['exchange'] = vi.fn(async () => '/workspace/file.md'),
+): AdminSessionBootstrapRuntime {
+    return {
+        location,
+        hideDocument: vi.fn(),
+        replaceUrl: vi.fn(),
+        reload: vi.fn(),
+        exchange,
+        openFallback: vi.fn(),
+    };
+}
+
+describe('admin session bootstrap', () => {
+    it('only recognizes the dedicated fragment key on normal pages', () => {
+        expect(bootstrapNonce({
+            pathname: '/workspace/file.md',
+            search: '',
+            hash: '#bootstrap_nonce=abc123',
+        })).toBe('abc123');
+        expect(bootstrapNonce({
+            pathname: '/workspace/file.md',
+            search: '',
+            hash: '#nonce=document-anchor',
+        })).toBeNull();
+        expect(bootstrapNonce({
+            pathname: '/workspace/file.md',
+            search: '',
+            hash: '#heading',
+        })).toBeNull();
+    });
+
+    it('accepts old bootstrap links only on the compatibility route', () => {
+        expect(bootstrapNonce({
+            pathname: '/_/admin/bootstrap',
+            search: '',
+            hash: '#nonce=legacy',
+        })).toBe('legacy');
+        expect(bootstrapNonce({
+            pathname: '/_/admin',
+            search: '',
+            hash: '#nonce=legacy',
+        })).toBeNull();
+    });
+
+    it('hides and clears the first render before exchanging, then reloads the approved target', async () => {
+        const calls: string[] = [];
+        const testRuntime = runtime(
+            {
+                pathname: '/workspace/file.md',
+                search: '?mode=preview',
+                hash: '#bootstrap_nonce=secret',
+            },
+            vi.fn(async (nonce: string) => {
+                calls.push(`exchange:${nonce}`);
+                return '/workspace/file.md?mode=preview#section';
+            }),
+        );
+        testRuntime.hideDocument = vi.fn(() => calls.push('hide'));
+        testRuntime.replaceUrl = vi.fn((url: string) => calls.push(`replace:${url}`));
+        testRuntime.reload = vi.fn(() => calls.push('reload'));
+
+        await expect(runAdminSessionBootstrap(testRuntime)).resolves.toBe('reloading');
+        expect(calls).toEqual([
+            'hide',
+            'replace:/workspace/file.md?mode=preview',
+            'exchange:secret',
+            'replace:/workspace/file.md?mode=preview#section',
+            'reload',
+        ]);
+        expect(testRuntime.openFallback).not.toHaveBeenCalled();
+    });
+
+    it('does nothing without a bootstrap fragment', async () => {
+        const testRuntime = runtime({
+            pathname: '/workspace/file.md',
+            search: '',
+            hash: '#heading',
+        });
+
+        await expect(runAdminSessionBootstrap(testRuntime)).resolves.toBe('inactive');
+        expect(testRuntime.hideDocument).not.toHaveBeenCalled();
+        expect(testRuntime.exchange).not.toHaveBeenCalled();
+        expect(testRuntime.reload).not.toHaveBeenCalled();
+    });
+
+    it('opens the manual administrator fallback when exchange fails', async () => {
+        const testRuntime = runtime(
+            {
+                pathname: '/workspace/file.md',
+                search: '',
+                hash: '#bootstrap_nonce=expired',
+            },
+            vi.fn(async () => {
+                throw new Error('expired');
+            }),
+        );
+
+        await expect(runAdminSessionBootstrap(testRuntime)).resolves.toBe('fallback');
+        expect(testRuntime.openFallback).toHaveBeenCalledWith('/_/admin');
+        expect(testRuntime.reload).not.toHaveBeenCalled();
+    });
+
+    it('posts the nonce and rejects an unsafe redirect', async () => {
+        const fetchMock = vi.fn(async () => new Response(
+            JSON.stringify({ redirect: '//evil.example/' }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+        ));
+
+        await expect(exchangeAdminNonce('secret', fetchMock)).rejects.toThrow(
+            'invalid admin bootstrap redirect',
+        );
+        expect(fetchMock).toHaveBeenCalledWith('/_/admin/session', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ nonce: 'secret' }),
+        });
+    });
+});

--- a/crates/core/assets/js/admin-session-boot.ts
+++ b/crates/core/assets/js/admin-session-boot.ts
@@ -1,0 +1,103 @@
+/**
+ * Redeem a one-time administrator capability from the final page URL.
+ *
+ * This is a classic, parser-blocking bundle loaded at the start of every HTML
+ * shell. When a bootstrap fragment is present it hides the unauthenticated
+ * render before first paint, removes the secret from the address bar, exchanges
+ * it for an HttpOnly cookie, then reloads the server-approved target in place.
+ */
+
+const BOOTSTRAP_NONCE_KEY = 'bootstrap_nonce';
+const LEGACY_BOOTSTRAP_PATH = '/_/admin/bootstrap';
+const LEGACY_NONCE_KEY = 'nonce';
+const ADMIN_FALLBACK_PATH = '/_/admin';
+
+type BootstrapLocation = Pick<Location, 'hash' | 'pathname' | 'search'>;
+
+export interface AdminSessionBootstrapRuntime {
+    location: BootstrapLocation;
+    hideDocument: () => void;
+    replaceUrl: (url: string) => void;
+    reload: () => void;
+    exchange: (nonce: string) => Promise<string>;
+    openFallback: (url: string) => void;
+}
+
+export type AdminSessionBootstrapResult = 'inactive' | 'reloading' | 'fallback';
+
+export function bootstrapNonce(location: BootstrapLocation): string | null {
+    if (!location.hash.startsWith('#')) return null;
+    const fragment = new URLSearchParams(location.hash.slice(1));
+    const nonce = fragment.get(BOOTSTRAP_NONCE_KEY);
+    if (nonce) return nonce;
+    if (location.pathname === LEGACY_BOOTSTRAP_PATH) {
+        return fragment.get(LEGACY_NONCE_KEY) || null;
+    }
+    return null;
+}
+
+function safeRedirect(value: unknown): string {
+    if (typeof value !== 'string' || !value.startsWith('/') || value.startsWith('//')) {
+        throw new Error('invalid admin bootstrap redirect');
+    }
+    return value;
+}
+
+export async function exchangeAdminNonce(
+    nonce: string,
+    fetchImpl: typeof fetch = window.fetch.bind(window),
+): Promise<string> {
+    const response = await fetchImpl('/_/admin/session', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce }),
+    });
+    if (!response.ok) throw new Error(`admin bootstrap exchange failed: ${response.status}`);
+    const result = await response.json() as { redirect?: unknown };
+    return safeRedirect(result.redirect);
+}
+
+export async function runAdminSessionBootstrap(
+    runtime: AdminSessionBootstrapRuntime,
+): Promise<AdminSessionBootstrapResult> {
+    const nonce = bootstrapNonce(runtime.location);
+    if (!nonce) return 'inactive';
+
+    runtime.hideDocument();
+    // Remove the secret synchronously, before the exchange or any other page
+    // script can copy the URL. The server-approved redirect is restored later.
+    runtime.replaceUrl(`${runtime.location.pathname}${runtime.location.search}`);
+
+    try {
+        const redirect = await runtime.exchange(nonce);
+        // replaceState + reload guarantees a real document request even when
+        // the redirect only adds a heading fragment to the current URL.
+        runtime.replaceUrl(redirect);
+        runtime.reload();
+        return 'reloading';
+    } catch {
+        runtime.openFallback(ADMIN_FALLBACK_PATH);
+        return 'fallback';
+    }
+}
+
+const root = document.documentElement;
+void runAdminSessionBootstrap({
+    location: window.location,
+    hideDocument: () => {
+        root.style.visibility = 'hidden';
+    },
+    replaceUrl: (url) => {
+        window.history.replaceState(null, '', url);
+    },
+    reload: () => {
+        window.location.reload();
+    },
+    exchange: (nonce) => exchangeAdminNonce(nonce),
+    openFallback: (url) => {
+        window.location.replace(url);
+    },
+});
+
+export {};

--- a/crates/core/assets/templates/access-gate.html
+++ b/crates/core/assets/templates/access-gate.html
@@ -2,6 +2,7 @@
 <html lang="en" data-theme="{{ theme }}" data-theme-default="{{ theme }}">
 <head>
   {% include "theme-boot.html" %}
+  {% include "admin-session-boot.html" %}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Markon</title>

--- a/crates/core/assets/templates/admin-bootstrap.html
+++ b/crates/core/assets/templates/admin-bootstrap.html
@@ -2,6 +2,7 @@
 <html lang="en" data-theme="{{ theme }}" data-theme-default="{{ theme }}">
 <head>
   {% include "theme-boot.html" %}
+  {% include "admin-session-boot.html" %}
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Markon Admin</title>

--- a/crates/core/assets/templates/admin-session-boot.html
+++ b/crates/core/assets/templates/admin-session-boot.html
@@ -1,0 +1,1 @@
+<script src="/_/js/admin-session-boot.js"></script>

--- a/crates/core/assets/templates/chat.html
+++ b/crates/core/assets/templates/chat.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="auto" data-theme="{{ theme }}" data-theme-default="{{ theme }}">
 <head>
     {% include "theme-boot.html" %}
+    {% include "admin-session-boot.html" %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="workspace-id" content="{{ workspace_id }}">

--- a/crates/core/assets/templates/directory.html
+++ b/crates/core/assets/templates/directory.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="auto" data-theme="{{ theme }}" data-theme-default="{{ theme }}">
 <head>
     {% include "theme-boot.html" %}
+    {% include "admin-session-boot.html" %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Directory Listing - markon</title>

--- a/crates/core/assets/templates/file-view.html
+++ b/crates/core/assets/templates/file-view.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="auto" data-theme="{{ theme }}" data-theme-default="{{ theme }}">
 <head>
     {% include "theme-boot.html" %}
+    {% include "admin-session-boot.html" %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }}</title>

--- a/crates/core/assets/templates/git-diff.html
+++ b/crates/core/assets/templates/git-diff.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="auto" data-theme="{{ theme }}" data-theme-default="{{ theme }}" data-editor-theme="{{ editor_theme | default(value='follow') }}">
 <head>
     {% include "theme-boot.html" %}
+    {% include "admin-session-boot.html" %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="workspace-id" content="{{ workspace_id }}">

--- a/crates/core/assets/templates/git-history.html
+++ b/crates/core/assets/templates/git-history.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="auto" data-theme="{{ theme }}" data-theme-default="{{ theme }}">
 <head>
     {% include "theme-boot.html" %}
+    {% include "admin-session-boot.html" %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }}</title>

--- a/crates/core/assets/templates/git-refs.html
+++ b/crates/core/assets/templates/git-refs.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="auto" data-theme="{{ theme }}" data-theme-default="{{ theme }}">
 <head>
     {% include "theme-boot.html" %}
+    {% include "admin-session-boot.html" %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ title }}</title>

--- a/crates/core/assets/templates/layout.html
+++ b/crates/core/assets/templates/layout.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="auto" data-theme="{{ theme }}" data-theme-default="{{ theme }}" data-editor-theme="{{ editor_theme | default(value='follow') }}" data-print-collapsed-content="{{ print_collapsed_content | default(value=false) }}">
 <head>
     {% include "theme-boot.html" %}
+    {% include "admin-session-boot.html" %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="file-path" content="{{ file_path }}">

--- a/crates/core/src/control/tests.rs
+++ b/crates/core/src/control/tests.rs
@@ -28,8 +28,11 @@ async fn harness() -> Harness {
 
     let registry = Arc::new(WorkspaceRegistry::new("test-salt".into()));
     let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
-    let admin: AdminBootstrapFn =
-        Arc::new(|redirect: &str| Ok(format!("http://127.0.0.1:7000{redirect}#nonce=abc")));
+    let admin: AdminBootstrapFn = Arc::new(|redirect: &str| {
+        Ok(format!(
+            "http://127.0.0.1:7000{redirect}#bootstrap_nonce=abc"
+        ))
+    });
     let admin_code: AdminBootstrapCodeFn = Arc::new(|_redirect: &str| {
         Ok((
             "http://127.0.0.1:7000/_/admin".to_string(),
@@ -192,7 +195,7 @@ async fn control_round_trips_every_method() {
 
     // admin_bootstrap — routed through the injected issuer.
     let url = h.client.admin_bootstrap("/workspace/").await.unwrap();
-    assert_eq!(url, "http://127.0.0.1:7000/workspace/#nonce=abc");
+    assert_eq!(url, "http://127.0.0.1:7000/workspace/#bootstrap_nonce=abc");
     let (manual_url, code) = h.client.admin_bootstrap_code("/workspace/").await.unwrap();
     assert_eq!(manual_url, "http://127.0.0.1:7000/_/admin");
     assert_eq!(code, "123456");

--- a/crates/core/src/server.rs
+++ b/crates/core/src/server.rs
@@ -517,6 +517,19 @@ pub fn build_workspace_url(base: &str, workspace_path: &str) -> String {
     format!("{}{}", base.trim_end_matches('/'), suffix)
 }
 
+fn build_admin_bootstrap_url(base: &str, redirect: &str, nonce: &str) -> String {
+    // The fragment is replaced by the final page after the exchange, so keep
+    // any original heading only in the server-side redirect. A literal '#'
+    // cannot be part of the HTTP route used for the initial document request.
+    let initial_route = redirect
+        .split_once('#')
+        .map_or(redirect, |(route, _fragment)| route);
+    format!(
+        "{}#bootstrap_nonce={nonce}",
+        build_workspace_url(base, initial_route)
+    )
+}
+
 fn canonicalize_route_path(path: &FsPath) -> std::io::Result<PathBuf> {
     // `std::fs::canonicalize` returns verbatim (`\\?\`) paths on Windows.
     // Workspace roots are stored through `dunce`, so route containment checks
@@ -1168,16 +1181,14 @@ pub async fn start(config: ServerConfig) -> Result<(), String> {
     })?;
     let control_socket_path = control_server.name().as_str().to_string();
 
-    // Admin bootstrap over the control socket mints a one-time browser URL
-    // against the web plane's featured base (the same URL a local browser uses).
+    // Admin bootstrap over the control socket opens the final page with a
+    // one-time fragment capability. The page exchanges it without exposing the
+    // nonce to the initial HTTP request, then reloads in place as administrator.
     let admin_bootstraps_for_control = admin_bootstraps.clone();
     let admin_base = local_base.clone();
     let admin_bootstrap_fn: crate::control::AdminBootstrapFn = Arc::new(move |redirect: &str| {
         let nonce = admin_bootstraps_for_control.issue_url(redirect);
-        Ok(format!(
-            "{}#nonce={nonce}",
-            build_workspace_url(&admin_base, "/_/admin/bootstrap")
-        ))
+        Ok(build_admin_bootstrap_url(&admin_base, redirect, &nonce))
     });
     let admin_bootstraps_for_code = admin_bootstraps.clone();
     let admin_code_base = local_base.clone();
@@ -1278,8 +1289,7 @@ pub async fn start(config: ServerConfig) -> Result<(), String> {
         };
         let redirect = first_workspace_url_path.as_deref().unwrap_or("/");
         let nonce = admin_bootstraps.issue_url(redirect);
-        let bootstrap = build_workspace_url(&base, "/_/admin/bootstrap");
-        let url = format!("{bootstrap}#nonce={nonce}");
+        let url = build_admin_bootstrap_url(&base, redirect, &nonce);
         if let Err(e) = open::that(&url) {
             tracing::warn!("best-effort browser open failed: {e}");
         }
@@ -7788,6 +7798,28 @@ mod tests {
         assert_eq!(r.all[2].url, "http://10.0.0.5:6419");
         // No advertised preference → first interface is featured (not localhost).
         assert_eq!(r.featured, "http://192.168.1.20:6419");
+    }
+
+    #[test]
+    fn admin_bootstrap_url_starts_at_final_route_with_fragment_nonce() {
+        assert_eq!(
+            build_admin_bootstrap_url(
+                "http://192.168.1.20:6419/",
+                "/workspace/file.md?mode=preview",
+                "abc123"
+            ),
+            "http://192.168.1.20:6419/workspace/file.md?mode=preview#bootstrap_nonce=abc123"
+        );
+        // The original heading remains in the server-side redirect stored with
+        // the nonce; it must not displace the bootstrap fragment in the first URL.
+        assert_eq!(
+            build_admin_bootstrap_url(
+                "http://127.0.0.1:6419",
+                "/workspace/file.md#heading",
+                "abc123"
+            ),
+            "http://127.0.0.1:6419/workspace/file.md#bootstrap_nonce=abc123"
+        );
     }
 
     #[test]

--- a/crates/gui/src/commands.rs
+++ b/crates/gui/src/commands.rs
@@ -510,9 +510,9 @@ pub async fn open_url(url: String, state: State<'_, AppState>) -> Result<(), Str
         (handle, base)
     };
     let markon_prefix = format!("{}/", base.trim_end_matches('/'));
-    // A markon URL is opened through a one-time administrator bootstrap minted by
-    // the service over the control socket, so the local browser lands with an
-    // admin session. Non-markon URLs (and the detached case) open as-is.
+    // A markon URL is opened with a one-time administrator fragment minted by
+    // the service over the control socket, so the local browser upgrades the
+    // final page in place. Non-markon URLs (and the detached case) open as-is.
     let target = match remote {
         Some(remote) if url.starts_with(&markon_prefix) => {
             let parsed = url::Url::parse(&url).map_err(|error| error.to_string())?;

--- a/crates/gui/src/main.rs
+++ b/crates/gui/src/main.rs
@@ -353,8 +353,8 @@ fn handle_open_path(app: &tauri::AppHandle, path: &Path) {
     };
 
     // Pure frontend: register the workspace on the service over its control
-    // socket, then mint a one-time admin-bootstrap URL so the local browser
-    // lands with an admin session — the same treatment `open_url` gives.
+    // socket, then mint the final page URL with a one-time admin fragment so
+    // the local browser upgrades in place — the same treatment `open_url` gives.
     // Directories register the whole tree; files use the single-file add so only
     // the pinned file (plus its assets) is reachable.
     let Some(remote) = state.server.lock().unwrap().handle() else {

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -156,6 +156,15 @@ async function build() {
     format: 'iife',
     target: ['es2022'],
   };
+  // Parser-blocking bootstrap controller shared by every HTML shell. It must
+  // run before first paint so the unauthenticated render never flashes.
+  const adminSessionBootOpts = {
+    ...shared,
+    entryPoints: [resolve(srcDir, 'admin-session-boot.ts')],
+    outfile: resolve(outDir, 'admin-session-boot.js'),
+    format: 'iife',
+    target: ['es2022'],
+  };
   const gitRefsOpts = {
     ...shared,
     entryPoints: [resolve(srcDir, 'git-refs.ts')],
@@ -212,6 +221,7 @@ async function build() {
     const ctxLayoutPage = await esbuild.context(layoutPageOpts);
     const ctxAccessGate = await esbuild.context(accessGateOpts);
     const ctxAdminBootstrap = await esbuild.context(adminBootstrapOpts);
+    const ctxAdminSessionBoot = await esbuild.context(adminSessionBootOpts);
     const ctxGitRefs = await esbuild.context(gitRefsOpts);
     const ctxPageShortcuts = await esbuild.context(pageShortcutsOpts);
     const ctxMathRender = await esbuild.context(mathRenderOpts);
@@ -227,6 +237,7 @@ async function build() {
     await ctxLayoutPage.watch();
     await ctxAccessGate.watch();
     await ctxAdminBootstrap.watch();
+    await ctxAdminSessionBoot.watch();
     await ctxGitRefs.watch();
     await ctxPageShortcuts.watch();
     await ctxMathRender.watch();
@@ -245,6 +256,7 @@ async function build() {
       esbuild.build(layoutPageOpts),
       esbuild.build(accessGateOpts),
       esbuild.build(adminBootstrapOpts),
+      esbuild.build(adminSessionBootOpts),
       esbuild.build(gitRefsOpts),
       esbuild.build(pageShortcutsOpts),
       esbuild.build(mathRenderOpts),


### PR DESCRIPTION
## What changed

- Mint administrator bootstrap capabilities directly onto the requested final workspace URL.
- Add a parser-blocking page controller that removes the fragment secret, exchanges it for the HttpOnly administrator cookie, restores the server-approved target, and reloads in place.
- Keep `/_/admin/bootstrap#nonce=...` compatible for existing links and retain the manual code fallback.
- Preserve custom base URLs, query strings, and server-side heading redirects across CLI and GUI launch paths.

## Root cause and impact

Native launches previously opened a dedicated bootstrap page, redirected to the target, and briefly rendered a panel that users could not meaningfully interact with. Starting on the final URL eliminates the extra navigation and visual flash without putting the one-time nonce in the HTTP request.

## Validation

- Unit coverage for normal-page/legacy fragment recognition, exchange ordering, URL scrubbing, fallback behavior, unsafe redirects, custom bases, and heading redirects.
- Browser E2E: final workspace URL opens directly, the first render stays hidden during exchange, the nonce disappears, administrator capabilities are active after one reload, and nonce replay returns 401.
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `npm test` (478 tests)
- `npm run typecheck`
- `npm run lint`
