### PR TITLE
fix(icons): declare the docs logo crop in the brand manifest

### DIFF
--- a/assets/brand/variants.toml
+++ b/assets/brand/variants.toml
@@ -91,20 +91,31 @@ outputs = [
   { path = "crates/gui/icons/tray.png", size = 64 },
   # In-app About page (CSS mask — fill colour is irrelevant, alpha is used).
   { path = "crates/gui/ui/glyph.svg" },
-  # Docs site logo, dark-theme variant (white glyph on dark page).
+]
+
+# ── Docs site logo ──────────────────────────────────────────────────────────
+# Both themes crop tighter than the tray does: "2 4 28 24" trims the vertical
+# padding the glyph carries inside its 32-square, so the mark sits flush with
+# the site header text instead of floating above it. The tray keeps the square
+# "2 2 28 28" — its icon has to stay optically centred in a square slot, which
+# is why the docs logos are their own variants rather than extra outputs on
+# `tray-template`.
+[[variant]]
+name = "docs-logo-dark"
+wrap = "none"
+fg = "#ffffff"
+viewBox = "2 4 28 24"
+outputs = [
+  # Dark-theme variant (white glyph on a dark page).
   { path = "docs/public/logo-dark.svg" },
 ]
 
-# ── Bare glyph, dark (docs light-theme logo) ────────────────────────────────
-# The Windows / Linux tray icon used to come from this variant. It's moved
-# to the wrapped `app` variant above — a flat black glyph was nearly
-# invisible on Windows 11's dark taskbar and looked weak on any taskbar
-# without the auto-tint macOS provides.
 [[variant]]
 name = "glyph-dark"
 wrap = "none"
 fg = "#27ae60"
+viewBox = "2 4 28 24"
 outputs = [
-  # Docs site logo, light-theme variant (black glyph on light page).
+  # Light-theme variant (green glyph on a light page).
   { path = "docs/public/logo-light.svg" },
 ]


### PR DESCRIPTION
The `Brand Icons` job (`cargo xtask icons --check`) has been red on main since the documentation refresh — see `f8df727` and `634760a`, where every other job passed. It is unrelated to any open PR.

## Cause

`docs/public/logo-dark.svg` and `logo-light.svg` are generated files, but they were hand-edited in `f877c8b` ("Refresh documentation visuals") from the generated viewBox to `"2 4 28 24"` — trimming the vertical padding the glyph carries inside its 32-square so the mark sits flush with the site header. The generator was never told, so it reported both files as stale on every run.

## Fix

Record the crop in `assets/brand/variants.toml` rather than reverting the visual change.

`logo-dark.svg` was an extra output on the `tray-template` variant, which uses `viewBox = "2 2 28 28"`. It could not carry a different crop without also recropping `tray.svg`, `tray.png` and `glyph.svg`, which are correct today — so the docs dark logo becomes its own `docs-logo-dark` variant. `glyph-dark`, which emits the light logo, gains the same `viewBox`.

## Verification

Ran `cargo xtask icons` after the change: all eight outputs regenerate **byte for byte identical** to what is committed — `git status` shows only `variants.toml` modified. `cargo xtask icons --check` then reports `icons up to date`.

So there is no visual change of any kind. This only teaches the generator a fact that was already true on disk.

Labelled `release:skip`: `assets/brand/variants.toml` is a build input, nothing shipped changes.