### PR TITLE
test: DO NOT MERGE — branch protection canary

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -16,3 +16,9 @@ pub(crate) mod fswalk;
 pub(crate) mod markdown;
 pub(crate) mod markdown_ast;
 pub(crate) mod workspace_fs;
+
+/// Deliberately misformatted so `cargo fmt --check` fails. This branch exists
+/// only to prove that branch protection actually blocks a merge; it must never
+/// be merged. See the pull request body.
+#[allow(dead_code)]
+fn   protection_canary( )   ->   u8 {   42   }


### PR DESCRIPTION
**Do not merge. This is a test fixture.**

`crates/core/src/lib.rs` gains a deliberately misformatted function so that **`Format`** — one of the required status checks — fails. Every other check should pass, which makes this a clean probe of one thing only: whether a red *required* check actually blocks the merge button.

This distinguishes the real question from the noise. `Brand Icons` failing on earlier PRs never blocked anything, because it is not a required check — that was correct behaviour, not a hole.

## What to look for

**Before** `enforce_admins` is enabled: as a repository administrator you should see the merge button available with a bypass warning along the lines of *"Merging can be performed automatically... you can bypass the rules"*. That is the hole being closed.

**After** it is enabled: the merge button should be disabled for everyone, administrators included, with the required check listed as failing.

Delete the branch once the check is done.