### PR TITLE
chore: bump to 0.15.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "markon"
-version = "0.15.20"
+version = "0.15.21"
 dependencies = [
  "clap",
  "crossterm",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "markon-core"
-version = "0.15.20"
+version = "0.15.21"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -3719,7 +3719,7 @@ dependencies = [
 
 [[package]]
 name = "markon-gui"
-version = "0.15.20"
+version = "0.15.21"
 dependencies = [
  "dirs",
  "dunce",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "markond"
-version = "0.15.20"
+version = "0.15.21"
 dependencies = [
  "dirs",
  "markon-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 
 [workspace.package]
-version = "0.15.20"
+version = "0.15.21"
 edition = "2021"
 authors = ["kookyleo"]
 license = "Apache-2.0"


### PR DESCRIPTION
Automated version bump for #86 (`patch`): `0.15.20` → `0.15.21`.

Merging this cuts `v0.15.21-rc.1` via `auto-rc.yml`. Labelled `release:skip` so it does not bump the version again on its way in.