### PR TITLE
chore: update Homebrew cask and Scoop manifest for 0.15.21

### DIFF
--- a/Casks/markon.rb
+++ b/Casks/markon.rb
@@ -1,8 +1,8 @@
 cask "markon" do
-  arch arm: "aarch64", intel: "x64"
+  arch arm: "aarch64", intel: "14b336d7adcb53677c343c6d670564486d5ccd4af9aef7ac5a74cd7048e06344"
 
-  version "0.15.6"
-  sha256 arm:   "135b62741681a3bc21f08adbca4cfd73fdd0b703ae3029e94b358ca0ccc76845",
+  version "0.15.21"
+  sha256 arm:   "1203f24fbff85953110375ce3d0e686d521b0273f9cac35bc7f370edcd786f9d",
          intel: "dba1abc6cfffa0cd54de7b608ed50e98ebc798c32f256cfa67b55a9f08f1c850"
 
   url "https://github.com/kookyleo/markon/releases/download/v#{version}/Markon_#{version}_#{arch}.dmg",

--- a/bucket/markon.json
+++ b/bucket/markon.json
@@ -1,16 +1,16 @@
 {
-    "version": "0.13.10",
+    "version": "0.15.21",
     "description": "Turn your markdown on. Lightweight Markdown renderer with GitHub styling.",
     "homepage": "https://github.com/kookyleo/markon",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/kookyleo/markon/releases/download/v0.13.10/Markon_0.13.10_x64-setup.exe",
-            "hash": "d0c26098287cb9555d4dbb2069fad8203bf561822cc20c1f38ed92baac82d01a"
+            "url": "https://github.com/kookyleo/markon/releases/download/v0.15.21/Markon_0.15.21_x64-setup.exe",
+            "hash": "92ab0607e184df64fb7ca1af72e359dd06c3bc2fe67d337aa812652fd7af738f"
         },
         "arm64": {
-            "url": "https://github.com/kookyleo/markon/releases/download/v0.13.10/Markon_0.13.10_arm64-setup.exe",
-            "hash": "914130a6293e9921cddb87e6484afce349b4229ad9b21b323c980baceccda899"
+            "url": "https://github.com/kookyleo/markon/releases/download/v0.15.21/Markon_0.15.21_arm64-setup.exe",
+            "hash": "d8f7e408c0bf0937a61aa55e7e44bc7697a6df3088a2734fc7446b7e410a60b8"
         }
     },
     "installer": {


### PR DESCRIPTION
Automated tap refresh for the `0.15.21` stable release. Labelled `release:skip` so it does not cut a version of its own.